### PR TITLE
pacemaker rpm is required before openais service starts

### DIFF
--- a/chef/cookbooks/corosync/attributes/default.rb
+++ b/chef/cookbooks/corosync/attributes/default.rb
@@ -21,7 +21,8 @@ default[:corosync][:mcast_port]   = 5405
 
 case node.platform
 when 'suse'
-  default[:corosync][:platform][:packages] = %w(sle-hae-release corosync openais)
+  default[:corosync][:platform][:packages] = \
+    %w(sle-hae-release corosync openais pacemaker)
 
   # The UNIX user for the cluster is typically determined by the
   # cluster-glue package:


### PR DESCRIPTION
Otherwise the corosync process fails to fork /usr/lib64/pacemaker/cib
on startup, and we get errors like:

  Could not establish cib_rw connection: Connection refused (111)
