### PR TITLE
silence warnings during rspec test runs

### DIFF
--- a/chef/cookbooks/pacemaker/recipes/default.rb
+++ b/chef/cookbooks/pacemaker/recipes/default.rb
@@ -39,7 +39,12 @@ if node[:pacemaker][:setup_hb_gui]
 end
 
 if Chef::Config[:solo]
-  ::Chef::Log.warn "Using Chef Solo, you are expected to manually include the corosync default recipe!"
+  unless ENV['RSPEC_RUNNING']
+    Chef::Application.fatal! \
+      "pacemaker::default needs corosync::default which uses search, " \
+      "but Chef Solo does not support search."
+    return
+  end
 else
   include_recipe "corosync::default"
 end

--- a/chef/cookbooks/pacemaker/spec/spec_helper.rb
+++ b/chef/cookbooks/pacemaker/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'chefspec'
 
+ENV['RSPEC_RUNNING'] = 'true'
+
 RSpec.configure do |config|
   # config.mock_with :rspec do |mocks|
   #   # This option should be set when all dependencies are being loaded


### PR DESCRIPTION
If we're testing via rspec, we don't need to include any corosync recipes, so we don't need to warn about anything.

However if we're _not_ testing and we're still using Chef Solo, then `pacemaker::default` can't possibly work, due to `corosync::authkey` requiring Chef search.  In this case we need to abort.
