### PR TITLE
add Pacemaker-aware alternative service provider

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/files/default/pacemaker_maintenance_handlers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/files/default/pacemaker_maintenance_handlers.rb
@@ -1,0 +1,69 @@
+# Ensure that we exit Pacemaker maintenance mode when appropriate.
+# See the crowbar-pacemaker::maintenance-mode recipe for more
+# information.
+
+class Chef
+  module Pacemaker
+    class Handler < Chef::Handler
+      include CrowbarPacemaker::MaintenanceModeHelpers
+    end
+
+    class StartHandler < Handler
+      def report
+        # This is informational only, and gives us a fraction more
+        # information in /var/log/chef/client.log and in the default
+        # attributes (until next run) for debugging purposes.
+        # However, it will only take effect after the handler has been
+        # installed in /etc/chef/client.rb *and* chef-client daemon
+        # has subsequently been restarted; the
+        # reload_chef_client_config hack doesn't work with
+        # start_handlers since it reloads the config too late, after
+        # the start handlers have already been triggered.
+        start_mode = record_maintenance_mode_before_this_chef_run
+        Chef::Log.info("Pacemaker maintenance mode currently %s" %
+                       [start_mode ? 'on' : 'off'])
+
+        if maintenance_mode_set_via_this_chef_run?
+          # Sanity check: this should never happen because we're using
+          # default attributes which get wiped for each chef-client run.
+          raise "BUG: Pacemaker maintenance mode was already set at the start of this run! (pid #$$)"
+        end
+      end
+    end
+
+    class ReportHandler < Handler
+      def report
+        if maintenance_mode_set_via_this_chef_run?
+          # Chef::Provider::PacemakerService must have handled at
+          # least one :restart action, so we know we need to take
+          # the node out of maintenance mode.
+
+          if maintenance_mode?
+            Chef::Log.info("Taking node out of Pacemaker maintenance mode")
+            system("crm node ready")
+          else
+            # This shouldn't happen, and suggests that one of the recipes
+            # is interfering in a way it shouldn't.
+            raise "Something took node out of maintenance mode during run!"
+          end
+        else
+          if maintenance_mode?
+            Chef::Log.warn("Node placed in Pacemaker maintenance mode but " +
+                           "not by Chef::Provider::PacemakerService; leaving as is")
+          else
+            Chef::Log.debug("Node not in Pacemaker maintenance mode")
+          end
+        end
+      end
+    end
+
+    class ExceptionHandler < Handler
+      def report
+        if maintenance_mode_set_via_this_chef_run?
+          Chef::Log.warn("chef-client run failed; leaving node in Pacemaker maintenance mode")
+          Chef::Log.warn("Manual clean-up required!  (Finish via 'crm node ready'.)")
+        end
+      end
+    end
+  end
+end

--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -1,0 +1,54 @@
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module CrowbarPacemaker
+  # A mixin for Chef::Pacemaker::Handler subclasses, and also for the
+  # Chef::Provider::PacemakerService LWRP.
+  module MaintenanceModeHelpers
+    def maintenance_mode?
+      !! (%x(crm node show #{node.hostname}) =~ /maintenance:\s*on/)
+    end
+
+    def record_maintenance_mode_before_this_chef_run
+      # Via Chef::Pacemaker::StartHandler we track whether anything
+      # has put the node into Pacemaker maintenance mode prior to this
+      # chef-client run.  This may come in handy during debugging.
+      # 
+      # We use a default attribute so that it will get reset at the
+      # beginning of each chef-client run.
+      node.default[:pacemaker][:maintenance_mode][$$][:at_start] = maintenance_mode?
+    end
+
+    def set_maintenance_mode_via_this_chef_run
+      # We track whether anything has put the node into Pacemaker
+      # maintenance mode during this chef-client run, so we know
+      # whether to take it out of maintenance mode again at the end of
+      # the run without interfering with external influences which
+      # might set it.
+      # 
+      # We use a default attribute so that it will get reset at the
+      # beginning of each chef-client run.
+      node.default[:pacemaker][:maintenance_mode][$$][:via_chef] = true
+    end
+
+    def maintenance_mode_set_via_this_chef_run?
+      # The "== true" is required because Chef::Node::Attribute does
+      # auto-vivification on read (!), so the value will be initialized
+      # to an empty Chef::Node::Attribute if not already set to true.
+      node.default[:pacemaker][:maintenance_mode][$$][:via_chef] == true
+    end
+  end
+end

--- a/chef/cookbooks/crowbar-pacemaker/providers/service.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/service.rb
@@ -1,0 +1,211 @@
+# Cookbook Name:: crowbar-pacemaker
+# Provider:: service
+#
+# Copyright:: 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an alternative provider for Chef's "service" platform resource.
+# It allows us to make an existing service resource Pacemaker-aware by
+# adding a single line:
+#
+#   service "foo" do
+#     service_name ...
+#     supports :status => true, :start => true, :restart => true
+#     action [ :enable, :start ]
+#     subscribes :restart, resources(:template => "/etc/foo.conf")
+#     provider Chef::Provider::CrowbarPacemakerService if ha_enabled
+#   end
+#
+# This effectively disables most of the resource's standard functionality,
+# the expectation being that you will also define a pacemaker_primitive
+# resource after this service block, which will cause Pacemaker to assume
+# management of the service.
+
+require 'mixlib/shellout'
+
+this_dir = ::File.dirname(__FILE__)
+require ::File.expand_path('../libraries/maintenance_mode_helpers', this_dir)
+
+# Disable the traditional service since it should only ever be started
+# by Pacemaker - if you violate that contract with Pacemaker then it
+# can get very confused and Bad Things will probably happen.
+[:enable, :disable].each do |a|
+  action a do
+    name = new_resource.service_name
+    Chef::Log.info("Disabling #{name} service; will be managed by Pacemaker instead")
+    proxy_action(new_resource, :disable)
+  end
+end
+
+[:start, :stop].each do |a|
+  action a do
+    name = new_resource.service_name
+    # Similarly to above, ignore start/stop since this will be handled
+    # by the pacemaker_primitive LWRP instead.
+    Chef::Log.info("Ignoring #{a} action for #{name} service since managed by Pacemaker instead")
+  end
+end
+
+# We still have to honour restart.  This is because some service
+# resources will have a "subscribes" line like the above, for handling
+# when some aspect of the service's configuration changes.
+#
+# This is surprisingly tricky to do right.  We have to perform the
+# restart in a way which does not violate the contract we have
+# regarding Pacemaker "owning" management of the service.  So there
+# are only two options: either the restart has to be done through the
+# Pacemaker interface, or we have to temporarily suspend Pacemaker's
+# management of the service.
+#
+# Secondly, chef-client will run on every node in the cluster, but
+# Pacemaker operations are cluster-wide because they affect the CIB
+# rather than individual nodes directory.  So for example we can't
+# just do a "crm resource restart $service" on each node, because that
+# would result in n attempts to restart the service, which could quite
+# possibly happen in a near simultaneous fashion (if triggered as part
+# of a proposal being applied).
+#
+# A similar synchronization problem occurs if we attempt to
+# temporarily "unmanage" the service (either by setting
+# is-managed="false" or setting the resource's maintenance mode flag
+# to true, the latter requiring a package update since it was only
+# introduced since the GM release of HAE for SLES11 SP3), then restart
+# the service ourselves, and then restore the maintenance mode flag
+# back to false - since this flag is cluster-wide, multiple nodes
+# would race over its value, so the only viable solution would be a
+# global lock which would cause the chef-clients to block in a serial
+# fashion, and that obviously sucks.
+#
+# One approach considered was to handle restart of the resource
+# through Pacemaker, but in the case where it could be running on
+# multiple nodes, handle the restart separately for each node.
+# However, we don't know in advance on which node(s) in the cluster
+# the resource is running.  Even if it's a clone, there's no guarantee
+# that it's running on all nodes (e.g. clone-max could be less than
+# the number of nodes in the cluster).  So we need to ensure that we
+# only attempt a restart if the resource is running on *this* node
+# (the one on which the chef-client is running).
+#
+# Unfortunately, Pacemaker doesn't provide any native way to restart
+# an individual clone.  So the best we could do in the clone case is
+# to temporarily force Pacemaker to stop the clone instance on this
+# node, and then remove that restriction.  This could be achieved by
+# creating a temporary -infinity location constraint which prohibits
+# the resource from running on this node, waiting for it to take
+# effect, and then removing the constraint.  But that has the
+# unfortunate side effect of potentially starting up the resource on a
+# different node.
+#
+# There are several further complications to this approach.  The
+# "service" resource (the one this provider will be consumed by) would
+# need to know, or at least be able to programmatically figure out the
+# name of the clone on whose behalf it can perform the restart action.
+# This is not just an "inappropriate intimacy" code smell, but also
+# impossible to implement in a way which would support a clone of a
+# group of services.  It's not possible for an alternate provider to
+# widen the attributes the resource accepts, and the cluster resource
+# name cannot be passed via the existing "service_name" attribute
+# (since that has to refer to the LSB service name).  So either the
+# "service" resource gets named after the Pacemaker resource requiring
+# the restart, in which case it may violate Chef's requirement for
+# resources of a given type to have unique names (since several
+# "service" resources within a cloned group would then end up with the
+# same clone name), or some naming scheme enforced by helper methods
+# is relied upon, but embedding relationship cardinality meta-data
+# into this namespace is very problematic.
+#
+# Also, by restarting via Pacemaker, there is no way to restart the
+# one service in the group without also restarting the others (in the
+# case where the service is not the last one to start up).
+#
+# After all those considerations, it turns out that the cleanest
+# solution is to use Pacemaker's ability to put individual *nodes*
+# (not resources) into maintenance mode.  This way we can safely
+# restart the resource in the normal way (i.e. not via Pacemaker),
+# without worrying of any of the above, or requiring any knowledge of
+# the cluster resource configuration.  It's also semantically cleaner,
+# because Chef runs perform operations which can certainly be
+# considered as genuine maintenance (albeit automated).  So this may
+# protect us against other things we haven't yet encountered.
+#
+# Taking a node out of maintenance mode will trigger a re-probe for
+# all the resources on that node.  Therefore we want to avoid toggling
+# maintenance mode on the node multiple times during a single
+# chef-client run.  To achieve this, we enable maintenance mode for
+# the node when the first restart action is encountered, and add a
+# report handler to Chef so that at the end of the run, maintenance
+# mode is disabled if need be.  This will leave the node in
+# maintenance mode if either:
+#
+#   1. it already was at the beginning of the chef-client run, or
+#   
+#   2. the chef-client run fails, in which case it is expected that it
+#      is more commonly a good thing than a bad one to leave it in
+#      maintenance mode, since manual clean-up would typically be
+#      required at that point.
+
+include CrowbarPacemaker::MaintenanceModeHelpers
+
+action :restart do
+  resource = new_resource.name
+  service_name = new_resource.service_name
+  this_node = node.hostname
+
+  if service_is_running?(service_name)
+    if maintenance_mode_set_via_this_chef_run?
+      Chef::Log.info("chef-client run pid $$ already placed this node in Pacemaker maintenance mode")
+    else
+      if maintenance_mode?
+        Chef::Log.info("Something else already placed this node in Pacemaker maintenance mode")
+      else
+        execute "crm node maintenance" do
+          action :nothing
+        end.run_action(:run)
+        set_maintenance_mode_via_this_chef_run
+      end
+    end
+
+    proxy_action(new_resource, :restart)
+  else
+    Chef::Log.info("Ignoring restart action for #{resource} service since not running on this node (#{this_node})")
+  end
+end
+
+# We also have to honour :reload, for similar reasons to :restart.
+# However, a reload does not stop a running service, so it's safe to
+# do directly via the service with no risk of confusing Pacemaker.
+action :reload do
+  service_name = new_resource.service_name
+  if service_is_running?(service_name)
+    proxy_action(new_resource, :reload)
+  else
+    Chef::Log.info("Ignoring reload action for #{service_name} service since not running on this node (#{node.hostname})")
+  end
+end
+
+def service_is_running?(name)
+  %x{service #{name} status}
+  $?.success?
+end
+
+def proxy_action(resource, service_action)
+  # This service name needs to be unique per resource *and* action,
+  # otherwise we get warnings about the resource attributes being
+  # cloned from the prior resource (CHEF-3694).
+  service "pacemaker-#{service_action}-of-#{resource.name}" do
+    service_name resource.service_name
+    action :nothing
+  end.run_action(service_action)
+end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -84,3 +84,5 @@ if node[:pacemaker][:haproxy][:enabled]
     retry_delay 5
   end
 end
+
+include_recipe "crowbar-pacemaker::maintenance-mode"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/maintenance-mode.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/maintenance-mode.rb
@@ -1,0 +1,60 @@
+#
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: maintenance-mode
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+directory "/var/chef/handlers"
+
+cookbook_file "pacemaker_maintenance_handlers" do
+  path "/var/chef/handlers/pacemaker_maintenance_handlers.rb"
+  source "pacemaker_maintenance_handlers.rb"
+end
+
+bash "register Pacemaker maintenance handlers" do
+  code <<'EOC'
+    cat >> /etc/chef/client.rb <<EOF
+
+require '/var/chef/cache/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers'
+require '/var/chef/handlers/pacemaker_maintenance_handlers'
+
+pacemaker_start_handler = Chef::Pacemaker::StartHandler.new
+start_handlers << pacemaker_start_handler # these fire at the beginning of a run
+
+pacemaker_report_handler = Chef::Pacemaker::ReportHandler.new
+report_handlers << pacemaker_report_handler # these fire at the end of a successful run
+
+pacemaker_exception_handler = Chef::Pacemaker::ExceptionHandler.new
+exception_handlers << pacemaker_exception_handler # these fire at the end of a failed run
+EOF
+EOC
+  not_if "grep -q pacemaker_maintenance_handlers /etc/chef/client.rb"
+end
+
+loaded = \
+  Chef::Handler.start_handlers .find { |h| h.class.to_s == 'Chef::Pacemaker::StartHandler'  } &&
+  Chef::Handler.report_handlers.find { |h| h.class.to_s == 'Chef::Pacemaker::ReportHandler' }
+
+if loaded
+  Chef::Log.debug("Pacemaker maintenance handlers already installed")
+else
+  Chef::Log.info("Pacemaker maintenance handlers not installed; " +
+                 "scheduling Chef config reload")
+  ruby_block "reload_chef_client_config" do
+    block { Chef::Config.from_file("/etc/chef/client.rb") }
+    action :create
+  end
+end

--- a/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/standard_cib_object.rb
@@ -25,7 +25,7 @@ class Chef
       def standard_load_current_resource
         name = @new_resource.name
 
-        cib_object = Pacemaker::CIBObject.from_name(name)
+        cib_object = ::Pacemaker::CIBObject.from_name(name)
         unless cib_object
           ::Chef::Log.debug "CIB object definition nil or empty"
           return
@@ -55,7 +55,7 @@ class Chef
           action :nothing
         end.run_action(:run)
 
-        created_cib_object = Pacemaker::CIBObject.from_name(new_resource.name)
+        created_cib_object = ::Pacemaker::CIBObject.from_name(new_resource.name)
 
         raise "Failed to create #{cib_object}" if created_cib_object.nil?
         unless created_cib_object.exists?


### PR DESCRIPTION
This is an alternative provider for Chef's "service" platform resource.  It allows us to make an existing service resource Pacemaker-aware by adding a single line to the service block.

Seems to work fine for me - apparently no problem having both `service` and `pacemaker_primitive` resources with the same name ...
