### PR TITLE
Translate _ from pacemaker proposal name to - in hostnames

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -31,7 +31,12 @@ module CrowbarPacemakerHelper
   # hostname.
   def self.cluster_vhostname(node)
     if cluster_enabled?(node)
-      "cluster-#{cluster_name(node)}"
+      # We know that the proposal name cannot contain a dash, and we know that
+      # a hostname cannot contain an underscore, so we're lucky and we can
+      # substitute one with the other
+      # Similar code is in the barclamp side:
+      # allocate_virtual_ips_for_cluster_in_networks
+      "cluster-#{cluster_name(node)}".gsub("_", "-")
     else
       nil
     end


### PR DESCRIPTION
The proposal names can only have letters or an underscore in their name.

A hostname cannot have an underscore in its name, but can have a dash.

As we build a virtual hostname based on the proposal name, we simply
translate the underscore to a dash so we're valid.
