### PR TITLE
Install openstack-resource-agents from crowbar-pacemaker cookbook

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
@@ -19,6 +19,8 @@
 
 # We're in the pacemaker barclamp, so we're using the pacemaker namespace
 
+default[:pacemaker][:platform][:resource_packages][:openstack] = %w(openstack-resource-agents)
+
 default[:pacemaker][:haproxy][:enabled] = false
 default[:pacemaker][:haproxy][:agent] = "lsb:haproxy"
 default[:pacemaker][:haproxy][:networks] = {}

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -19,6 +19,18 @@
 
 include_recipe "pacemaker::default"
 
+# if we ever want to not have a hard dependency on openstack here, we can have
+# Crowbar set a node[:pacemaker][:resource_agents] attribute based on available
+# barclamps, and do:
+# node[:pacemaker][:resource_agents].each do |resource_agent|
+#   node[:pacemaker][:platform][:resource_packages][resource_agent].each do |pkg|
+#     package pkg
+#   end
+# end
+node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
+  package pkg
+end
+
 #FIXME: delete group when it's not needed anymore 
 #FIXME: need to find/write OCF for haproxy  
 


### PR DESCRIPTION
It's not extremely clean to do openstack bits here, but it simplifies
many things. If this barclamp will be used for non-openstack setups too,
then we can actually have Crowbar orchestrate things to tell the
cookbook about which resource agents to install.
