### PR TITLE
Limit number of pacemaker-cluster-member nodes to 31

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -33,7 +33,7 @@ class PacemakerService < ServiceObject
         },
         "pacemaker-cluster-member" => {
           "unique" => false,
-          "count" => -1
+          "count" => 31
         },
         "hawk-server" => {
           "unique" => false,


### PR DESCRIPTION
According to the following, it is not supported to have more than 32
nodes in a cluster:
https://www.suse.com/documentation/sle_ha/book_sleha/data/sec_ha_requirements_hw.html

Since we have one founder, that means 31 non-founders.
