### PR TITLE
correctly parse empty parameter values in CIB objects

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb
@@ -45,7 +45,7 @@ module Pacemaker
       h = {}
       Shellwords.split($1).each do |kvpair|
         break if kvpair == 'op'
-        unless kvpair =~ /^(.+?)=(.+)$/
+        unless kvpair =~ /^(.+?)=(.*)$/
           raise "Couldn't understand '#{kvpair}' for '#{data_type}' section "\
             "of #{name} primitive (definition was [#{obj_definition}])"
         end


### PR DESCRIPTION
For a CIB object definition such as:

```
primitive database-config-default-fs ocf:heartbeat:Filesystem \
        params device="/dev/drbd/postgresql" directory="/var/lib/pgsql" fstype="" \
        op monitor interval="10s"
```

when `#extract_hash` attempts to extract the `params` section, `Shellwords.split` will return an `Array` whose last element is

```
fstype=
```

not

```
fstype=""
```

as you might expect.  Therefore we need to allow for an empty string to
the right of the equals sign, otherwise parsing fails.
