### PR TITLE
Clear gem paths after installing ruby-shadow

### DIFF
--- a/chef/cookbooks/corosync/recipes/service.rb
+++ b/chef/cookbooks/corosync/recipes/service.rb
@@ -71,6 +71,14 @@ user node[:corosync][:user] do
   password node[:corosync][:password]
 end
 
+# After installation of ruby-shadow, we have a new path for the new gem, so we
+# need to reset the paths if we can't load ruby-shadow
+begin
+  require 'shadow'
+rescue LoadError
+  Gem.clear_paths
+end
+
 service node[:corosync][:platform][:service_name] do
   supports :restart => true, :status => :true
   action [:enable, :start]


### PR DESCRIPTION
When ruby-shadow gets installed, chef-client will not have the gem in
the gem paths, so we need to clear the paths to make it work. The test
to detect this case is easy: we simply try to load the gem.

This will fix chef-client daemon so that they will work fine after
ruby-shadow has been installed.
