### PR TITLE
Make pacemaker barclamp setup the LVM for DRBD

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -6,4 +6,5 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1"
 
 depends "haproxy"
+depends "lvm"
 depends "pacemaker"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -44,6 +44,10 @@ node[:pacemaker][:platform][:resource_packages][:openstack].each do |pkg|
   package pkg
 end
 
+if node[:pacemaker][:drbd][:enabled]
+  include_recipe "crowbar-pacemaker::drbd"
+end
+
 include_recipe "crowbar-pacemaker::haproxy"
 
 include_recipe "crowbar-pacemaker::maintenance-mode"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: crowbar-pacemaker
+# Recipe:: drbd
+#
+# Copyright 2014, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+claim_string = "LVM_DRBD"
+lvm_group = "drbd"
+lvm_disk = nil
+
+unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sort
+claimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, claim_string).sort
+
+if claimed_disks.empty? and not unclaimed_disks.empty?
+  unclaimed_disks.each do |disk|
+    if disk.claim(claim_string)
+      Chef::Log.info("#{claim_string}: Claimed #{disk.name}")
+      lvm_disk = disk
+      break
+    else
+      Chef::Log.info("#{claim_string}: Ignoring #{disk.name}")
+    end
+  end
+else
+  lvm_disk = claimed_disks.first
+end
+
+if lvm_disk.nil?
+  message = "There is no suitable disk for LVM for DRBD!"
+  Chef::Log.fatal(message)
+  raise message
+end
+
+include_recipe "lvm::default"
+
+lvm_physical_volume lvm_disk.name
+
+lvm_volume_group lvm_group do
+  physical_volumes [lvm_disk.name]
+end
+
+node["drbd"]["master"] = node["pacemaker"]["founder"]

--- a/chef/data_bags/crowbar/bc-template-pacemaker.json
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.json
@@ -26,6 +26,9 @@
           "hypervisor_ip": ""
         }
       },
+      "drbd": {
+        "enabled": false
+      },
       "haproxy": {
         "public_name": ""
       }

--- a/chef/data_bags/crowbar/bc-template-pacemaker.schema
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.schema
@@ -69,6 +69,12 @@
                     "hypervisor_ip": { "type": "str", "required": true }
                   }
                 }
+            },
+            "drbd": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "enabled": { "type": "bool", "required": true }
               }
             },
             "haproxy": {

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -207,6 +207,10 @@ class PacemakerService < ServiceObject
       end
     end
 
+    if proposal["attributes"][@bc_name]["drbd"]["enabled"]
+      validation_error "Setting up DRBD requires a cluster of two nodes." if members.length != 2
+    end
+
     nodes = NodeObject.find("roles:provisioner-server")
     unless nodes.nil? or nodes.length < 1
       provisioner_server_node = nodes[0]

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -39,6 +39,15 @@
 
     %fieldset
       %legend
+        = t(".drbd_header")
+
+      .alert.alert-info
+        = t(".drbd.info")
+
+      = boolean_field %w(drbd enabled)
+
+    %fieldset
+      %legend
         = t(".haproxy_header")
 
       .alert.alert-info

--- a/crowbar_framework/config/locales/pacemaker.en.yml
+++ b/crowbar_framework/config/locales/pacemaker.en.yml
@@ -4,6 +4,10 @@ en:
   barclamp:
     pacemaker:
       edit_attributes:
+        drbd_header: DRBD
+        drbd:
+          info: Using DRBD for replicated storage is an alternative to using shared storage for high availability of services like database and RabbitMQ. This requires the cluster to have two nodes only, as well as one dedicated disk on each cluster member.
+          enabled: Prepare cluster for DRBD
         haproxy_header: HAProxy
         haproxy:
           ssl_info:


### PR DESCRIPTION
We add a new option to allow the user to tell whether DRBD is going to
be used. If that's the case, then we create the LVM setup that the other
barclamps will then use.
