### PR TITLE
corosync: Do not regenerate authkey if file exists

### DIFF
--- a/chef/cookbooks/corosync/recipes/authkey_generator.rb
+++ b/chef/cookbooks/corosync/recipes/authkey_generator.rb
@@ -38,6 +38,7 @@ execute "corosync-keygen" do
   group "root"
   umask "0400"
   action :run
+  not_if { ::File.exists?(authkey_file) }
 end
 
 # Read authkey (it's binary) into encoded format and save to Chef server


### PR DESCRIPTION
To decide whether to generate the authkey, we simply check if the
attribute is set on the node. If it's not but the authkey file exists,
we should simply re-use the existing authkey and import it to the
attribute.

This will allow changing the founder node to another node of the
cluster.
