### PR TITLE
Make stonith data-nodes attribute smaller.

### DIFF
--- a/crowbar_framework/app/helpers/pacemaker_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/pacemaker_barclamp_helper.rb
@@ -17,6 +17,10 @@
 #
 
 module PacemakerBarclampHelper
+  def node_aliases
+    Hash[nodes_hash.map { |n| [n.first, { :alias => n.last[:alias] }] }]
+  end
+
   def no_quorum_policy_for_pacemaker(selected)
     # no translation for the strings as we simply show the values that will end
     # up in the config file

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -19,7 +19,7 @@
         = string_field %w(stonith shared agent)
         = string_field %w(stonith shared params)
 
-      #stonith_per_node_container{ "data-nodes" => Hash[nodes_hash.map { |n| [n.first, { :alias => n.last[:alias] }] }].to_json }
+      #stonith_per_node_container{ "data-nodes" => node_aliases.to_json }
         = string_field %w(stonith per_node agent)
         %table.table.table-middle
           %thead


### PR DESCRIPTION
The nodes hash can get quite large. So just cherry pick the alias
attribute, in which the form.js code is interested, to keep it smaller.
