### PR TITLE
Include drbd::default recipe from crowbar-pacemaker

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
@@ -52,4 +52,4 @@ lvm_volume_group lvm_group do
   physical_volumes [lvm_disk.name]
 end
 
-node["drbd"]["master"] = node["pacemaker"]["founder"]
+include_recipe "drbd::default"


### PR DESCRIPTION
We need to install the drbd bits before they can be used.

Also, since the master information will be per-resource, stop defining
it.
