### PR TITLE
Fix SSL setup for haproxy 1.4 release

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -34,30 +34,9 @@ listen  admin-stats <%= node[:haproxy][:stats][:enabled] ? node[:haproxy][:stats
   <% node[:haproxy][:sections][type].keys.sort.each do |name| -%>
     <% content = node[:haproxy][:sections][type][name] -%>
 <%= type %> <%= name %> <%= content[:address] %>:<%= content[:port] %>
-    <% if content[:use_ssl] # http://blog.exceliance.fr/2011/07/04/maintain-affinity-based-on-ssl-session-id/ -%>
-	mode tcp
-
-	# maximum SSL session ID length is 32 bytes.
-	stick-table type binary len 32 size 30k expire 30m
-
-	acl clienthello req_ssl_hello_type 1
-	acl serverhello rep_ssl_hello_type 2
-
-	# use tcp content accepts to detects ssl client and server hello.
-	tcp-request inspect-delay 5s
-	tcp-request content accept if clienthello
-
-	# no timeout on response inspect delay by default.
-	tcp-response content accept if serverhello
-
-	# SSL session ID (SSLID) may be present on a client or server hello.
-	# Its length is coded on 1 byte at offset 43 and its value starts
-	# at offset 44.
-	# Match and learn on request if client hello.
-	stick on payload_lv(43,1) if clienthello
-
-	# Learn on response if server hello.
-	stick store-response payload_lv(43,1) if serverhello
+    <% if content[:use_ssl] -%>
+       mode tcp
+       balance source
     <% else -%>
 	mode <%= content[:mode] %>
     <% end -%>


### PR DESCRIPTION
The old setup we created was using options that are only valid for 1.5
releases.
