### PR TITLE
make helpers permanent to defend against Chef cache wipe

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/files/default/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/files/default/maintenance_mode_helpers.rb
@@ -1,0 +1,1 @@
+../../libraries/maintenance_mode_helpers.rb

--- a/chef/cookbooks/crowbar-pacemaker/files/default/pacemaker_maintenance_handlers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/files/default/pacemaker_maintenance_handlers.rb
@@ -2,6 +2,15 @@
 # See the crowbar-pacemaker::maintenance-mode recipe for more
 # information.
 
+# These handlers will be loaded by Chef at startup, via
+# /etc/chef/client.rb.  At this point there is no guarantee that
+# /var/cache/chef is populated (crowbar_join will wipe the cache
+# during boot if its first chef-client run fails), so the
+# maintenance-mode recipe ensures that maintenance_mode_helpers.rb is
+# permanently installed under /var/chef/libraries at the same time the
+# handlers are installed in /etc/chef/client.rb.
+require '/var/chef/libraries/maintenance_mode_helpers'
+
 class Chef
   module Pacemaker
     class Handler < Chef::Handler

--- a/chef/cookbooks/crowbar-pacemaker/recipes/maintenance-mode.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/maintenance-mode.rb
@@ -24,11 +24,17 @@ cookbook_file "pacemaker_maintenance_handlers" do
   source "pacemaker_maintenance_handlers.rb"
 end
 
+directory "/var/chef/libraries"
+
+cookbook_file "maintenance_mode_helpers" do
+  path "/var/chef/libraries/maintenance_mode_helpers.rb"
+  source "maintenance_mode_helpers.rb"
+end
+
 bash "register Pacemaker maintenance handlers" do
   code <<'EOC'
     cat >> /etc/chef/client.rb <<EOF
 
-require '/var/chef/cache/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers'
 require '/var/chef/handlers/pacemaker_maintenance_handlers'
 
 pacemaker_start_handler = Chef::Pacemaker::StartHandler.new


### PR DESCRIPTION
If the maintenance mode handlers got installed, and then the node reboots and the first `chef-client` in `crowbar_join` fails, crowbar_join wipes `/var/cache/chef`, and that broke loading of the handlers via
`/etc/chef/client.rb` on `chef-client` startup, since `maintenance_mode_helpers.rb` would then be missing.

To defend against this, we additionally install the helpers into a permanent location outside the cache (`/var/chef/libraries`) at the same time the handlers are installed.

Supercedes https://github.com/crowbar/barclamp-pacemaker/pull/55.
