### PR TITLE
Fix dependecy on drbd cookbook

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -7,4 +7,5 @@ version          "0.1"
 
 depends "haproxy"
 depends "lvm"
+depends "drbd"
 depends "pacemaker"


### PR DESCRIPTION
Because in crowbar-pacemaker cookbook in recipe drbd.rb we include `include_recipe "drbd::default"` 
