### PR TITLE
add tmp/ to .gitignore

### DIFF
--- a/chef/cookbooks/pacemaker/.gitignore
+++ b/chef/cookbooks/pacemaker/.gitignore
@@ -1,1 +1,2 @@
 Gemfile.lock
+tmp/


### PR DESCRIPTION
For example, guard creates tmp/rspec_guard_result, and we
do not want to see that in `git status`.
