### PR TITLE
Change default STONITH mode to "per_node"

### DIFF
--- a/chef/data_bags/crowbar/bc-template-pacemaker.json
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.json
@@ -13,7 +13,7 @@
         "no_quorum_policy": "stop"
       },
       "stonith": {
-        "mode": "manual",
+        "mode": "per_node",
         "shared": {
           "agent": "",
           "params": ""


### PR DESCRIPTION
It's actually hard to come with a reasonable default for the proposal,
but "manual", which was the previous default, makes it way too easy for
people to ignore the fact that they need to configure STONITH manually,
which will lead to errors.

With "per_node", Crowbar will tell them that the proposal is not
complete and so it will force the user to think about STONITH.
