### PR TITLE
Decrease sleep during synchronization from 10s to 5s

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
@@ -76,7 +76,7 @@ module CrowbarPacemakerSynchronization
           end
 
           Chef::Log.debug("Waiting for cluster founder to set #{mark} to #{revision}...")
-          sleep(10)
+          sleep(5)
         end # while true
       end # Timeout
     rescue Timeout::Error
@@ -142,7 +142,7 @@ module CrowbarPacemakerSynchronization
           end
 
           Chef::Log.debug("Waiting for all cluster nodes to set #{mark} to #{revision}...")
-          sleep(10)
+          sleep(5)
         end # while true
       end # Timeout
     rescue Timeout::Error


### PR DESCRIPTION
10s really makes the whole chef run much longer.
