### PR TITLE
Make the attribute for enabling haproxy per cluster

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
@@ -21,7 +21,6 @@
 
 default[:pacemaker][:platform][:resource_packages][:openstack] = %w(openstack-resource-agents)
 
-default[:pacemaker][:haproxy][:enabled] = false
 default[:pacemaker][:haproxy][:agent] = "lsb:haproxy"
-default[:pacemaker][:haproxy][:networks] = {}
 default[:pacemaker][:haproxy][:op][:monitor][:interval] = "10s"
+default[:pacemaker][:haproxy][:clusters] = {}

--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -25,7 +25,9 @@
 # all nodes when needed (this avoids the need for "crm resource refresh")
 include_recipe "haproxy::setup"
 
-if node[:pacemaker][:haproxy][:enabled]
+cluster_name = CrowbarPacemakerHelper.cluster_name(node)
+
+if node[:pacemaker][:haproxy][:clusters].has_key?(cluster_name) && node[:pacemaker][:haproxy][:clusters][cluster_name][:enabled]
   service "haproxy" do
     supports :restart => true, :status => true, :reload => true
     action :nothing
@@ -35,7 +37,7 @@ if node[:pacemaker][:haproxy][:enabled]
   vip_primitives = []
   service_name = "haproxy"
 
-  node[:pacemaker][:haproxy][:networks].each do |network, enabled|
+  node[:pacemaker][:haproxy][:clusters][cluster_name][:networks].each do |network, enabled|
     vip_primitive = pacemaker_vip_primitive "HAProxy VIP for #{network}" do
       cb_network network
       # See allocate_cluster_virtual_ips_for_networks in barclamp-crowbar


### PR DESCRIPTION
Right now, it's global which means that all clusters for any role in a
proposal will enable haproxy, which is just wrong.

https://bugzilla.novell.com/show_bug.cgi?id=872528
