### PR TITLE
don't ignore synchronization failures by default

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
@@ -48,5 +48,5 @@ attribute :mark,      :kind_of => String,  :default => nil
 # this is optional in crowbar; the barclamp proposal revision will be used
 attribute :revision,  :kind_of => Integer, :default => nil
 
-attribute :fatal,     :kind_of => [TrueClass, FalseClass], :default => false
+attribute :fatal,     :kind_of => [TrueClass, FalseClass], :default => true
 attribute :timeout,   :kind_of => Integer, :default => 60


### PR DESCRIPTION
The `fatal` attribute of `crowbar_pacemaker's sync_mark` LWRP defaulted to false, so synchronization failures effectively got ignored - the only difference being an extra 60-second delay and a warning in the logs.

One symptom of ignoring synchronization failures is that Pacemaker resources get created and started before setup is complete on all nodes. This in turn causes fencing of nodes with incomplete setup when Pacemaker attempts to start up the resources on those nodes.

It's more user-friendly if rather than fencing, the chef-client run simply fails, since this gets bubbled up to the UI without unnecessary failovers or interruptions to existing services running on the node in question.

Of course, any synchronization which is advisory-only can still specify

```
fatal false
```

in the resource block.
