### PR TITLE
[WIP] register services managed by Pacemaker

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/service.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/service.rb
@@ -46,6 +46,17 @@ require ::File.expand_path('../libraries/maintenance_mode_helpers', this_dir)
     name = new_resource.service_name
     Chef::Log.info("Disabling #{name} service; will be managed by Pacemaker instead")
     proxy_action(new_resource, :disable)
+
+    inventory = '/var/lib/pacemaker/managed-services'
+
+    directory inventory do
+      action :nothing
+    end.run_action(:create)
+
+    file "#{inventory}/#{name}" do
+      content "written by chef-client pid #$$"
+      action :nothing
+    end.run_action(:create)
   end
 end
 


### PR DESCRIPTION
We keep track of which services are managed by Pacemaker, so that init scripts can refuse to start/stop those services unless run by Pacemaker. This protects against cloud operators erroneously attempting to start/stop the services due to muscle memory or simple ignorance of the [documented contract](https://www.suse.com/documentation/sle_ha/book_sleha/data/sec_ha_configuration_basics_resources.html).

**WARNING**: do not merge - not yet tested!  Need to debug DRBD issue first.