### PR TITLE
support parentheses in constraints

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
@@ -1,4 +1,5 @@
 require 'mixlib/shellout'
+require 'shellwords'
 
 module Pacemaker
   class CIBObject
@@ -144,8 +145,12 @@ module Pacemaker
         .gsub("'")  { "\\'" }
     end
 
+    def escaped_definition_string
+      Shellwords.join(Shellwords.split(definition_string))
+    end
+
     def configure_command
-      "crm configure " + definition_string
+      "crm configure " + escaped_definition_string
     end
 
     def reconfigure_command

--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
@@ -20,11 +20,11 @@ class Pacemaker::Constraint::Colocation < Pacemaker::Constraint
     end
     self.name  = $1
     self.score = $2
-    self.resources = $3.split
+    self.resources = $3
   end
 
   def definition_string
-    "#{self.class::TYPE} #{name} #{score}: " + resources.join(' ')
+    "#{self.class::TYPE} #{name} #{score}: #{resources}"
   end
 
 end

--- a/chef/cookbooks/pacemaker/resources/colocation.rb
+++ b/chef/cookbooks/pacemaker/resources/colocation.rb
@@ -26,4 +26,4 @@ attribute :score, :kind_of => String
 
 # If more than two resources are given, Pacemaker will treat this
 # as a resource set.
-attribute :resources, :kind_of => Array
+attribute :resources, :kind_of => String

--- a/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
@@ -7,7 +7,7 @@ module Chef::RSpec
       COLOCATION_CONSTRAINT = \
         ::Pacemaker::Constraint::Colocation.new('colocation1')
       COLOCATION_CONSTRAINT.score = 'inf'
-      COLOCATION_CONSTRAINT.resources = ['foo']
+      COLOCATION_CONSTRAINT.resources = 'foo'
       COLOCATION_CONSTRAINT_DEFINITION = 'colocation colocation1 inf: foo'
     end
   end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
@@ -56,6 +56,17 @@ EOF
     it "should parse the resources" do
       expect(@parsed.resources).to eq(fixture.resources)
     end
+  end
 
+  describe "#configure_command" do
+    it "should escape round parentheses" do
+      fixture.resources = '( a b ) c'
+      expect(fixture.configure_command).to include('\( a b \) c')
+    end
+
+    it "should escape square parentheses" do
+      fixture.resources = '[ a b ] c'
+      expect(fixture.configure_command).to include('\[ a b \] c')
+    end
   end
 end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/order_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/order_spec.rb
@@ -58,4 +58,16 @@ EOF
     end
 
   end
+
+  describe "#configure_command" do
+    it "should escape round parentheses" do
+      fixture.ordering = '( a b ) c'
+      expect(fixture.configure_command).to include('\( a b \) c')
+    end
+
+    it "should escape square parentheses" do
+      fixture.ordering = '[ a b ] c'
+      expect(fixture.configure_command).to include('\[ a b \] c')
+    end
+  end
 end

--- a/chef/cookbooks/pacemaker/spec/providers/colocation_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/colocation_spec.rb
@@ -43,7 +43,7 @@ describe "Chef::Provider::PacemakerColocation" do
     it "should modify the constraint if it has a resource added" do
       new_resource = 'bar:Stopped'
       expected = fixture.dup
-      expected.resources = expected.resources.dup + [new_resource]
+      expected.resources = expected.resources.dup + ' ' + new_resource
       expected_configure_cmd_args = [expected.reconfigure_command]
       test_modify(expected_configure_cmd_args) do
         @resource.resources expected.resources
@@ -51,7 +51,7 @@ describe "Chef::Provider::PacemakerColocation" do
     end
 
     it "should modify the constraint if it has a different resource" do
-      new_resources = ['bar:Started']
+      new_resources = 'bar:Started'
       fixture.resources = new_resources
       expected_configure_cmd_args = [fixture.reconfigure_command]
       test_modify(expected_configure_cmd_args) do


### PR DESCRIPTION
This is a backwards-incompatible but [unfortunately necessary](https://github.com/crowbar/barclamp-database/pull/77) change for the `pacemaker_colocation` LWRP.  However, it will be trivial to change the consumers to use a `String` instead of an `Array`.