### PR TITLE
pacemaker: Change default op timeout from 10 minutes to 1 minute

### DIFF
--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -33,6 +33,7 @@ end
 default[:pacemaker][:founder] = false
 default[:pacemaker][:crm][:initial_config_file] = "/etc/corosync/crm-initial.conf"
 default[:pacemaker][:crm][:no_quorum_policy] = "ignore"
+default[:pacemaker][:crm][:op_default_timeout] = 60
 
 # Values can be "disabled", "manual", "sbd", "shared", "per_node"
 default[:pacemaker][:stonith][:mode] = "disabled"

--- a/chef/cookbooks/pacemaker/recipes/setup.rb
+++ b/chef/cookbooks/pacemaker/recipes/setup.rb
@@ -27,7 +27,8 @@ template crm_conf do
   mode 0600
   variables(
     :stonith_enabled => (node[:pacemaker][:stonith][:mode] != "disabled"),
-    :no_quorum_policy => node[:pacemaker][:crm][:no_quorum_policy]
+    :no_quorum_policy => node[:pacemaker][:crm][:no_quorum_policy],
+    :op_default_timeout => node[:pacemaker][:crm][:op_default_timeout]
   )
 end
 

--- a/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
+++ b/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
@@ -3,7 +3,7 @@ property $id="cib-bootstrap-options" \
         no-quorum-policy="<%= @no_quorum_policy %>" \
         placement-strategy="balanced"
 op_defaults $id="op-options" \
-        timeout="600" \
+        timeout="<%= @op_default_timeout %>" \
         record-pending="true"
 rsc_defaults $id="rsc-options" \
         resource-stickiness="1" \


### PR DESCRIPTION
10 minutes is way too long and people have time to think that something
is just totally broken. 1 minute is more reasonable. And in the worst
case, an attribute can be set to change this now.
