### PR TITLE
sbd: Wait for cluster to be up after corosync restart

### DIFF
--- a/chef/cookbooks/pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/pacemaker/recipes/stonith.rb
@@ -68,6 +68,8 @@ when "sbd"
       # We want to allocate slots before restarting corosync
       notifies :run, "execute[Allocate SBD slot]", :immediately
       notifies :restart, "service[#{node[:corosync][:platform][:service_name]}]", :immediately
+      # After restarting corosync, we need to wait for the cluster to be online again
+      notifies :create, "ruby_block[wait for cluster to be online]", :immediately
     end
   end
 


### PR DESCRIPTION
Every time we start corosync, we need to wait for the cluster to be up.
And when we use sbd, we restart corosync to start sbd, so we need to
wait there too.
