### PR TITLE
Remove group resource

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/runnable_resource.rb
+++ b/chef/cookbooks/pacemaker/libraries/chef/mixin/pacemaker/runnable_resource.rb
@@ -26,7 +26,9 @@ class Chef
         unless @current_resource
           raise "Cannot stop non-existent #{cib_object_class.description} '#{name}'"
         end
-        return unless @current_cib_object.running?
+        unless cib_object_class.description.include? "group resource"
+          return unless @current_cib_object.running?
+        end
         execute @current_cib_object.crm_stop_command do
           action :nothing
         end.run_action(:run)
@@ -36,8 +38,10 @@ class Chef
 
       def delete_runnable_resource
         return unless @current_resource
-        if @current_cib_object.running?
-          raise "Cannot delete running #{@current_cib_object}"
+        unless cib_object_class.description.include? "group resource"
+          if @current_cib_object.running?
+            raise "Cannot delete running #{@current_cib_object}"
+          end
         end
         standard_delete_resource
       end


### PR DESCRIPTION
Dont check for running group resources.

``` ruby
pacemaker_group "g-glance" do
  action [:stop, :delete]
  only_if "crm configure show g-glance"
end 
```

when `only_if` is evaluated, `Mixlib::ShellOut::ShellCommandFailedexception` is raised and the recipe exits fatally.

in the [`running?`](https://github.com/crowbar/barclamp-pacemaker/blob/release/roxy/master/chef/cookbooks/pacemaker/libraries/pacemaker/resource.rb#L14) method following cmd is evaluated:
`crm resource status g-glance` which returns 1 and causes the Exception.

`crm resource status` contains groups, but not i.e. `g-glance`, the `g-$barclamp` ones which is questionable.
