### PR TITLE
fix Travis breakage

### DIFF
--- a/chef/cookbooks/pacemaker/Gemfile
+++ b/chef/cookbooks/pacemaker/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 group :test, :development do
   gem 'chefspec', '~> 3.0'
+  gem 'rspec-expectations', '~> 2.14.0'
   gem 'rubydeps'
 end
 


### PR DESCRIPTION
Travis started failing with:

```
uninitialized constant RSpec::Matchers::BuiltIn::RaiseError::MatchAliases (NameError)
```

Obviously don't merge this unless it actually fixes the breakage.
