### PR TITLE
Fixed length calls (bnc#879657)

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -79,10 +79,10 @@ class PacemakerService < ServiceObject
     @logger.debug("Pacemaker apply_role_pre_chef_call: entering #{all_nodes.inspect}")
 
     # elect a founder
-    members = role.override_attributes[@bc_name]["elements"]["pacemaker-cluster-member"]
+    members = role.override_attributes[@bc_name]["elements"]["pacemaker-cluster-member"] || []
     member_nodes = []
 
-    unless members.nil?
+    unless members.empty?
       member_nodes = members.map {|n| NodeObject.find_node_by_name n}
 
       founder = nil
@@ -279,8 +279,7 @@ class PacemakerService < ServiceObject
     validate_at_least_n_for_role proposal, "pacemaker-cluster-member", 1
 
     elements = proposal["deployment"]["pacemaker"]["elements"]
-
-    members = (elements["pacemaker-cluster-member" ] || [])
+    members = elements["pacemaker-cluster-member" ] || []
 
     if elements.has_key?("hawk-server")
       elements["hawk-server"].each do |n|


### PR DESCRIPTION
It is possible that crowbar bails out while apply a pacemaker proposal
with an exception that length is not a method of NilClass. With this fix
it should be fine now.

https://bugzilla.novell.com/show_bug.cgi?id=879657
