### PR TITLE
Use more descriptive msg on sbd init check failure

### DIFF
--- a/chef/cookbooks/pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/pacemaker/recipes/stonith.rb
@@ -42,7 +42,7 @@ when "sbd"
     command "test -c /dev/watchdog"
   end
 
-  execute "Check SBD validity" do
+  execute "Check that SBD was initialized using '#{sbd_cmd} create'." do
     command "#{sbd_cmd} dump &> /dev/null"
   end
 


### PR DESCRIPTION
Stonith + SBD deployment can fail due to SBD not being created on the
shared disk. The message does not really tell what went wrong and what
should be done to fix it. Use a more descriptive one.

The SBD creation is a destructive op and a typo could wipe the user
data, so this is the reason that sbd create is not run by default.

An alternative would be to run the sdb create only after user types
the volume name into the input field in the UI twice, for confirmation.
