### PR TITLE
Fix javascript after barclamp-crowbar change

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
@@ -113,7 +113,7 @@
 
     $.each(self.options.watchedRoles, function(index, role) {
       var role_path  = 'elements/{0}'.format(role);
-      var role_nodes = $(self.options.deployment_storage).readJsonAttribute(role_path);
+      var role_nodes = $(self.options.deployment_storage).readJsonAttribute(role_path, {});
       $.each(role_nodes, function(index, node) { deployed_nodes[node] = true; });
     });
 


### PR DESCRIPTION
https://github.com/crowbar/barclamp-crowbar/pull/1091 exposes a bug in
the javascript where we don't specify the default value of a json
attribute we try to read and that doesn't initially exist.
