### PR TITLE
Sort vip primitives when creating haproxy group

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -68,7 +68,7 @@ if node[:pacemaker][:haproxy][:clusters].has_key?(cluster_name) && node[:pacemak
   pacemaker_group "g-#{service_name}" do
     # Membership order *is* significant; VIPs should come first so
     # that they are available for the haproxy service to bind to.
-    members vip_primitives + [service_name]
+    members vip_primitives.sort + [service_name]
     action [ :create, :start ]
     retries 1
     retry_delay 5


### PR DESCRIPTION
Without the sort, the order of the VIP can change, and we keep updating
the haproxy group every now and then.
