### PR TITLE
Complete 558432f by dropping target-role on the chef resource too + do the same for clone/group/ms

### DIFF
--- a/chef/cookbooks/pacemaker/providers/clone.rb
+++ b/chef/cookbooks/pacemaker/providers/clone.rb
@@ -58,9 +58,16 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
+  deprecate_target_role
+
   Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
 
   desired_clone = cib_object_class.from_chef_resource(new_resource)
+
+  # See comment in primitive provider as to why we do this
+  new_resource.meta.delete('target-role')
+  desired_clone.meta.delete('target-role')
+
   if desired_clone.definition_string != @current_cib_object.definition_string
     Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_clone.definition_string}]"
     cmd = desired_clone.reconfigure_command

--- a/chef/cookbooks/pacemaker/providers/group.rb
+++ b/chef/cookbooks/pacemaker/providers/group.rb
@@ -57,9 +57,16 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
+  deprecate_target_role
+
   Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
 
   desired_group = cib_object_class.from_chef_resource(new_resource)
+
+  # See comment in primitive provider as to why we do this
+  new_resource.meta.delete('target-role')
+  desired_group.meta.delete('target-role')
+
   if desired_group.definition_string != @current_cib_object.definition_string
     Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_group.definition_string}]"
     cmd = desired_group.reconfigure_command

--- a/chef/cookbooks/pacemaker/providers/ms.rb
+++ b/chef/cookbooks/pacemaker/providers/ms.rb
@@ -62,15 +62,15 @@ def maybe_modify_resource(name)
 
   Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
 
-  desired_clone = cib_object_class.from_chef_resource(new_resource)
+  desired_ms = cib_object_class.from_chef_resource(new_resource)
 
   # See comment in primitive provider as to why we do this
   new_resource.meta.delete('target-role')
-  desired_clone.meta.delete('target-role')
+  desired_ms.meta.delete('target-role')
 
-  if desired_clone.definition_string != @current_cib_object.definition_string
-    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_clone.definition_string}]"
-    cmd = desired_clone.reconfigure_command
+  if desired_ms.definition_string != @current_cib_object.definition_string
+    Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_ms.definition_string}]"
+    cmd = desired_ms.reconfigure_command
     execute cmd do
       action :nothing
     end.run_action(:run)

--- a/chef/cookbooks/pacemaker/providers/ms.rb
+++ b/chef/cookbooks/pacemaker/providers/ms.rb
@@ -58,9 +58,16 @@ def create_resource(name)
 end
 
 def maybe_modify_resource(name)
+  deprecate_target_role
+
   Chef::Log.info "Checking existing #{@current_cib_object} for modifications"
 
   desired_clone = cib_object_class.from_chef_resource(new_resource)
+
+  # See comment in primitive provider as to why we do this
+  new_resource.meta.delete('target-role')
+  desired_clone.meta.delete('target-role')
+
   if desired_clone.definition_string != @current_cib_object.definition_string
     Chef::Log.debug "changed from [#{@current_cib_object.definition_string}] to [#{desired_clone.definition_string}]"
     cmd = desired_clone.reconfigure_command

--- a/chef/cookbooks/pacemaker/providers/primitive.rb
+++ b/chef/cookbooks/pacemaker/providers/primitive.rb
@@ -97,6 +97,7 @@ def maybe_modify_resource(name)
   #
   # This can result in a primitive not being started with [:create, :start].
   # Therefore, we just delete this deprecated bit from meta to avoid any issue.
+  new_resource.meta.delete('target-role')
   desired_primitive.meta.delete('target-role')
 
   if desired_primitive.op_string != @current_cib_object.op_string


### PR DESCRIPTION
Commit 558432f was not fully complete, as it's also important to drop
target-role from the chef resource, not just from the bit we're using to
check if we need to update the pacemaker resource.