### PR TITLE
Fix race on initial run where cluster founder is not found

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/default.rb
@@ -17,6 +17,32 @@
 # limitations under the License.
 #
 
+# Depending on how crowbar orchestrate things, a non-founder node might reach
+# this code while the founder node has not its attributes indexed yet on the
+# server side. This only happens the very first time (which is when we don't
+# even have an auth key); on next runs, we know we're good.
+if node[:corosync][:authkey].nil?
+  require 'timeout'
+
+  begin
+    Timeout.timeout(20) do
+      Chef::Log.info("Waiting for cluster founder to be indexed...")
+      while true
+        begin
+          founder = CrowbarPacemakerHelper.cluster_founder(node)
+          Chef::Log.info("Cluster founder found: #{founder.name}")
+          break
+        rescue
+          Chef::Log.info("No cluster founder found yet, waiting...")
+          sleep(2)
+        end
+      end # while true
+    end # Timeout
+  rescue Timeout::Error
+    Chef::Log.warn("Cluster founder not found!")
+  end
+end
+
 node[:corosync][:cluster_name] = CrowbarPacemakerHelper.cluster_name(node)
 
 # Enforce no-quorum-policy based on the number of members in the clusters


### PR DESCRIPTION
On the very first time we apply a pacemaker proposal, non-founder nodes
might be running chef-client faster than the founder node (depending on
how crowbar will order them) and this might result in the founder
attribute not being indexed fast enough. So the nodes will fail not
finding the founder.

So on this very first time, we wait a bit to make sure the founder will
be returned in our search results.
