### PR TITLE
Import authkey as attribute if file already existed

### DIFF
--- a/chef/cookbooks/corosync/recipes/authkey_generator.rb
+++ b/chef/cookbooks/corosync/recipes/authkey_generator.rb
@@ -52,6 +52,10 @@ ruby_block "Store authkey to Chef server" do
     node.set_unless[:corosync][:authkey] = packed
     node.save
   end
-  action :nothing
-  subscribes :create, resources(:execute => "corosync-keygen"), :immediately
+  # If we don't have the attribute, always read the key (even if it existed and
+  # we didn't run corosync-keygen)
+  unless node[:corosync][:authkey].nil?
+    action :nothing
+    subscribes :create, resources(:execute => "corosync-keygen"), :immediately
+  end
 end


### PR DESCRIPTION
On the founder node, when we generate the authkey, we actually only
import the authkey as an attribute if we create the authkey file. But if
the authkey file already exists, we don't do anything.

The result is that non-founder nodes are stuck because they don't have
access to the authkey.

This can happen after deactivating a pacemaker proposal, if the
attributes have been removed by the user, and then reactivating it.
