### PR TITLE
Tell pacemaker to start apache with -DSSL when apache needs SSL

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -40,11 +40,15 @@ end
 
 service_name            = "apache"
 
+apache_params = {}
+apache_params["statusurl"] = "http://127.0.0.1:#{listening_port}/server-status"
+unless crowbar_defined_ports.values.select{|service| service.has_key? :ssl}.empty?
+  apache_params["options"] = "-DSSL"
+end
+
 pacemaker_primitive service_name do
   agent agent_name
-  params ({
-      "statusurl" => "http://127.0.0.1:#{listening_port}/server-status"
-  })
+  params apache_params
   op    apache_op
   action :create
 end


### PR DESCRIPTION
This is really a workaround for a bug in SLE HAE:
  https://bugzilla.novell.com/show_bug.cgi?id=890209

The apache RA doesn't read /etc/sysconfig/apache2 to find out if -DSSL
should be used, so we have to do it ourselves.

https://bugzilla.novell.com/show_bug.cgi?id=889570
