### PR TITLE
Additional check for synchronization helpers, if HA was enabled

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/synchronization.rb
@@ -57,7 +57,10 @@ require 'timeout'
 module CrowbarPacemakerSynchronization
 
   # See "Synchronization helpers" documentation
-  def self.wait_for_mark_from_founder(node, mark, revision, fatal = false, timeout = 60)
+  def self.wait_for_mark_from_founder(node, mark, revision, fatal = false, timeout = 60, cookbook = "crowbar-pacemaker")
+
+    return unless node[cookbook].nil? || node[cookbook][:ha].nil? || node[cookbook][:ha][:enabled]
+
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
     return if CrowbarPacemakerHelper.is_cluster_founder?(node)
 
@@ -92,7 +95,10 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.set_mark_if_founder(node, mark, revision)
+  def self.set_mark_if_founder(node, mark, revision, cookbook = "crowbar-pacemaker")
+    
+    return unless node[cookbook].nil? || node[cookbook][:ha].nil? || node[cookbook][:ha][:enabled]
+
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
     return unless CrowbarPacemakerHelper.is_cluster_founder?(node)
 
@@ -110,7 +116,10 @@ module CrowbarPacemakerSynchronization
   end
 
   # See "Synchronization helpers" documentation
-  def self.synchronize_on_mark(node, mark, revision, fatal = false, timeout = 60)
+  def self.synchronize_on_mark(node, mark, revision, fatal = false, timeout = 60, cookbook = "crowbar-pacemaker")
+    
+    return unless node[cookbook].nil? || node[cookbook][:ha].nil? || node[cookbook][:ha][:enabled]
+
     return unless CrowbarPacemakerHelper.cluster_enabled?(node)
 
     cluster_name = CrowbarPacemakerHelper.cluster_name(node)

--- a/chef/cookbooks/crowbar-pacemaker/providers/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/sync_mark.rb
@@ -45,33 +45,33 @@ def get_options resource
   raise "Missing mark attribute" if mark.nil?
   raise "Missing revision attribute" if revision.nil?
 
-  [action, mark, revision]
+  [action, mark, revision, cookbook_name]
 end
 
 action :wait do
-  action, mark, revision = get_options(new_resource)
-  CrowbarPacemakerSynchronization.wait_for_mark_from_founder(node, mark, revision, new_resource.fatal, new_resource.timeout)
+  action, mark, revision, cookbook = get_options(new_resource)
+  CrowbarPacemakerSynchronization.wait_for_mark_from_founder(node, mark, revision, new_resource.fatal, new_resource.timeout, cookbook)
 end
 
 action :create do
-  action, mark, revision = get_options(new_resource)
-  CrowbarPacemakerSynchronization.set_mark_if_founder(node, mark, revision)
+  action, mark, revision, cookbook = get_options(new_resource)
+  CrowbarPacemakerSynchronization.set_mark_if_founder(node, mark, revision, cookbook)
 end
 
 action :sync do
-  action, mark, revision = get_options(new_resource)
-  CrowbarPacemakerSynchronization.synchronize_on_mark(node, mark, revision, new_resource.fatal, new_resource.timeout)
+  action, mark, revision, cookbook = get_options(new_resource)
+  CrowbarPacemakerSynchronization.synchronize_on_mark(node, mark, revision, new_resource.fatal, new_resource.timeout, cookbook)
 end
 
 action :guess do
-  action, mark, revision = get_options(new_resource)
+  action, mark, revision, cookbook = get_options(new_resource)
   raise "Cannot guess action based on resource name" if action.nil?
 
   if action == :wait
-    CrowbarPacemakerSynchronization.wait_for_mark_from_founder(node, mark, revision, new_resource.fatal, new_resource.timeout)
+    CrowbarPacemakerSynchronization.wait_for_mark_from_founder(node, mark, revision, new_resource.fatal, new_resource.timeout, cookbook)
   elsif action == :create
-    CrowbarPacemakerSynchronization.set_mark_if_founder(node, mark, revision)
+    CrowbarPacemakerSynchronization.set_mark_if_founder(node, mark, revision, cookbook)
   elsif action == :sync
-    CrowbarPacemakerSynchronization.synchronize_on_mark(node, mark, revision, new_resource.fatal, new_resource.timeout)
+    CrowbarPacemakerSynchronization.synchronize_on_mark(node, mark, revision, new_resource.fatal, new_resource.timeout, cookbook)
   end
 end


### PR DESCRIPTION
Additional check for synchronization helpers, if HA was enabled for service on node attaching to cluster

This fix bug 895780
https://bugzilla.novell.com/show_bug.cgi?id=895780
