### PR TITLE
Raise server/client timeouts to 3h

### DIFF
--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -19,8 +19,8 @@ defaults
 	timeout http-request 5s
 	timeout queue 1m
 	timeout connect 5s
-	timeout client 50s
-	timeout server 50s
+	timeout client 3h
+	timeout server 3h
 	timeout check 5s
 	balance <%= node[:haproxy][:defaults][:balance] %>
 


### PR DESCRIPTION
the 50s was generally by far too low, as it interrupts
api operations that take longer than that to complete
(like for example uploading a large glance image).
