### PR TITLE
Raise header bufsize to 32kb (bnc#900950)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -28,7 +28,7 @@ node.default['haproxy']['defaults']['balance'] = "source"
 
 # With the default bufsize, getting a keystone PKI token from its ID doesn't
 # work, because the URI path is too long for haproxy
-node.default['haproxy']['global']['bufsize'] = 24576
+node.default['haproxy']['global']['bufsize'] = 32768
 
 # Always do the setup for haproxy, so that the RA will already be available on
 # all nodes when needed (this avoids the need for "crm resource refresh")

--- a/chef/cookbooks/haproxy/attributes/default.rb
+++ b/chef/cookbooks/haproxy/attributes/default.rb
@@ -24,6 +24,7 @@ default[:haproxy][:platform][:config_file] = "/etc/haproxy/haproxy.cfg"
 
 default[:haproxy][:global][:maxconn] = 4096
 default[:haproxy][:global][:bufsize] = 16384
+default[:haproxy][:global][:maxrewrite] = 8192
 default[:haproxy][:global][:chksize] = 16384
 
 default[:haproxy][:defaults][:balance] = "roundrobin"

--- a/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
+++ b/chef/cookbooks/haproxy/templates/default/haproxy.cfg.erb
@@ -3,6 +3,7 @@ global
 	log 127.0.0.1   local1 notice
 	maxconn <%= node[:haproxy][:global][:maxconn] %>
 	tune.bufsize <%= node[:haproxy][:global][:bufsize] %>
+	tune.maxrewrite <%= node[:haproxy][:global][:maxrewrite] %>
 	tune.chksize <%= node[:haproxy][:global][:chksize] %>
 	chroot /var/lib/haproxy
 	user <%= node[:haproxy][:platform][:user] %>


### PR DESCRIPTION
It seems with multiple regions, the 24kb header size for
PKI tokens are exhausted pretty quickly. Raise to 32kb,
