### PR TITLE
Force output of "crm configure show" to not use colors

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/cib_object.rb
@@ -15,7 +15,7 @@ module Pacemaker
       end
 
       def get_definition(name)
-        cmd = Mixlib::ShellOut.new("crm configure show #{name}")
+        cmd = Mixlib::ShellOut.new("crm --display=plain configure show #{name}")
         cmd.environment['HOME'] = ENV.fetch('HOME', '/root')
         cmd.run_command
         begin


### PR DESCRIPTION
We don't care about colors, we just want to parse plain text.

This allows us to avoid being hit by this crmsh bug:
https://bugzilla.novell.com/show_bug.cgi?id=893011

(cherry picked from commit a3524fbcce943887d4d80ee0c587447c4c4fd0d9)
