### PR TITLE
Fix migration for transport key in schema (bnc#909056)

### DIFF
--- a/chef/data_bags/crowbar/bc-template-pacemaker.json
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.json
@@ -50,8 +50,9 @@
   },
   "deployment": {
     "pacemaker": {
-      "crowbar-revision": 10,
+      "crowbar-revision": 0,
       "crowbar-applied": false,
+      "schema-revision": 10,
       "element_states": {
         "pacemaker-cluster-member" : [ "readying", "ready", "applying" ],
         "hawk-server"              : [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-pacemaker.schema
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.schema
@@ -140,6 +140,7 @@
           "required": true,
           "mapping": {
             "crowbar-revision": { "type": "int", "required": true },
+            "schema-revision": { "type": "int" },
             "crowbar-committing": { "type": "bool" },
             "crowbar-applied": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },


### PR DESCRIPTION
The crowbar-revision key was bumped, while we really wanted
schema-revision.

https://bugzilla.suse.com/show_bug.cgi?id=909056
