### PR TITLE
Add missing explicit conversion from pathname to string, needed in rails 4

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service_object.rb
+++ b/crowbar_framework/app/models/pacemaker_service_object.rb
@@ -198,7 +198,7 @@ class PacemakerServiceObject < ServiceObject
     # cookbook code is executed faster. So far, it seems it's not an issue
     # (we're not even hitting the "will run chef-client a second time if first
     # one fails), but this would still need to be improved.
-    system("sudo", "-i", Rails.root.join("..", "bin", "single_chef_client.sh").expand_path)
+    system("sudo", "-i", Rails.root.join("..", "bin", "single_chef_client.sh").expand_path.to_s)
   end
 
   # This prepares attributes so that, if ha_enabled is true, the chef run will


### PR DESCRIPTION
Without this change, an exception is raised when deploying barclamps in HA config under rails4/ruby2.1.
