### PR TITLE
Make adding a node to a cluster give all roles from that cluster to node

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -88,7 +88,7 @@ class PacemakerService < ServiceObject
 
     all_nodes_for_cluster_role_expanded, failures = expand_nodes_for_all(all_nodes_for_cluster_role)
     unless failures.nil? || failures.empty?
-      @logger.debug "[pacemaker] expand_nodes_in_barclamp_role: skipping items that we failed to expand: #{failures.join(", ")}"
+      @logger.warn "[pacemaker] expand_nodes_in_barclamp_role: skipping items that we failed to expand: #{failures.join(", ")}"
     end
 
     # Do not keep deleted nodes
@@ -138,7 +138,7 @@ class PacemakerService < ServiceObject
         # Update elements_expanded attribute
         expanded_nodes, failures = expand_nodes_for_all(node_names)
         unless failures.nil? || failures.empty?
-          @logger.debug "[pacemaker] apply_cluster_roles_to_new_nodes: skipping items that we failed to expand: #{failures.join(", ")}"
+          @logger.warn "[pacemaker] apply_cluster_roles_to_new_nodes: skipping items that we failed to expand: #{failures.join(", ")}"
         end
 
         expanded_nodes.sort!

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -75,10 +75,16 @@ class PacemakerService < ServiceObject
     base
   end
 
+  # Small helper to get the list of nodes used by a barclamp proposal (applied
+  # or not)
+  def all_nodes_used_by_barclamp(role)
+    role.elements.values.flatten.compact.uniq
+  end
+
   # Small helper to expand all items (nodes, clusters) used inside an applied
   # proposal
   def expand_nodes_in_barclamp_role(cluster_role, node_object_all)
-    all_nodes_for_cluster_role = cluster_role.elements.values.flatten.compact.uniq
+    all_nodes_for_cluster_role = all_nodes_used_by_barclamp(cluster_role)
 
     all_nodes_for_cluster_role_expanded, failures = expand_nodes_for_all(all_nodes_for_cluster_role)
     unless failures.nil? || failures.empty?
@@ -108,7 +114,7 @@ class PacemakerService < ServiceObject
     # Find all barclamp roles where this cluster is used
     cluster_roles = RoleObject.all.select do |role_object|
       role_object.proposal? && \
-      role_object.elements.values.flatten.compact.uniq.include?(cluster_element)
+      all_nodes_used_by_barclamp(role_object).include?(cluster_element)
     end
 
     # Inside each barclamp role, identify which role is required


### PR DESCRIPTION
When a cluster already exists and is already used for, say, keystone,
applying the pacemaker proposal with a new node (to extend the cluster)
failed because that new node was not aware it should have the other
roles (keystone).

To fix this, we need to take some logic from apply_role inside
apply_role_pre_chef_call from pacemaker to ensure that all nodes have
the required roles, and also to ensure that we call
apply_role_pre_chef_call from all the required barclamp (we only do this
when we add a role).

It's also important to run apply_role_post_chef_call for each barclamp
where the new node was missing.
    
It's worth mentioning that the cluster resources will have to be cleaned
up on the new node, as (for instance) keystone will not be able to start
just after pacemaker got configued on the node and before keystone is
configured.