### PR TITLE
Fix libvirt stonith configuration (bnc#905038)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/stonith.rb
@@ -129,7 +129,7 @@ when "libvirt"
   hypervisor_uri = "qemu+tcp://#{hypervisor_ip}/system"
 
   CrowbarPacemakerHelper.cluster_nodes(node).each do |cluster_node|
-    unless cluster_node[:dmi][:system][:manufacturer] == "Bochs"
+    unless %w(Bochs QEMU).include? cluster_node[:dmi][:system][:manufacturer]
       message = "Node #{cluster_node[:hostname]} does not seem to be running in libvirt."
       Chef::Log.fatal(message)
       raise message

--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -276,7 +276,7 @@ class PacemakerService < ServiceObject
       end
       members.each do |member|
         node = NodeObject.find_node_by_name(member)
-        unless node[:dmi][:system][:manufacturer] == "Bochs"
+        unless %w(Bochs QEMU).include? node[:dmi][:system][:manufacturer]
           validation_error "Node  #{member} does not seem to be running in libvirt."
         end
       end


### PR DESCRIPTION
Newer kvm/qemu releases changed the Vendor name from "Bochs" to "QEMU".

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=905038
(cherry picked from commit ee6497912f4d1015fab575b1e8f3b76ccac464d4)