### PR TITLE
Add X-Stop-After header to corosync-shutdown init script

### DIFF
--- a/chef/cookbooks/corosync/recipes/service.rb
+++ b/chef/cookbooks/corosync/recipes/service.rb
@@ -123,6 +123,13 @@ if node[:corosync][:require_clean_for_autostart]
     )
   end
 
+  # Make sure that any dependency change is taken into account
+  bash "insserv #{corosync_shutdown} service" do
+    code "insserv #{corosync_shutdown}"
+    action :nothing
+    subscribes :run, resources(:template=> "/etc/init.d/#{corosync_shutdown}"), :delayed
+  end
+
   service corosync_shutdown do
     action :enable
   end

--- a/chef/cookbooks/corosync/templates/default/corosync-shutdown.init.erb
+++ b/chef/cookbooks/corosync/templates/default/corosync-shutdown.init.erb
@@ -8,6 +8,7 @@
 # Should-Start:      $null
 # Required-Stop:     $null
 # Should-Stop:       $syslog sshd drbd $named $remote_fs logd xendomains xend iscsi libvirtd portmap rpcbind
+# X-Stop-After:      <%= @service_name %>
 # Default-Start:     3 5
 # Default-Stop:      0 6
 # Description:       Clean file blocking <%= @service_name %> start after fencing


### PR DESCRIPTION
This helps ensure we run this after the corosync service is shutdown.
Until now, we were only relying on the fact that we stop that service
inside the init script.