### PR TITLE
Move fatal message out of default attributes

### DIFF
--- a/chef/cookbooks/pacemaker/attributes/default.rb
+++ b/chef/cookbooks/pacemaker/attributes/default.rb
@@ -47,8 +47,8 @@ else
   # * haveged
   #
 
-  Chef::Application.fatal! "FIXME: #{node.platform} platform not supported yet"
-  return
+  default[:pacemaker][:platform][:packages] = nil
+  default[:pacemaker][:platform][:graphical_packages] = nil
 end
 
 default[:pacemaker][:founder] = false

--- a/chef/cookbooks/pacemaker/recipes/default.rb
+++ b/chef/cookbooks/pacemaker/recipes/default.rb
@@ -18,6 +18,10 @@
 # limitations under the License.
 #
 
+if node[:pacemaker][:platform][:packages].nil?
+  Chef::Application.fatal! "FIXME: #{node.platform} platform not supported yet"
+end
+
 node[:pacemaker][:platform][:packages].each do |pkg|
   package pkg
 end


### PR DESCRIPTION
This is required so that we can use the libraries without being hurt by
this message.