### PR TITLE
Don't escape html for quorum doc link

### DIFF
--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -7,7 +7,7 @@
 
     = select_field %w(crm no_quorum_policy), :collection => :no_quorum_policy_for_pacemaker
     %span.help-block
-      = t('.crm.no_quorum_policy_hint')
+      = t('.crm.no_quorum_policy_hint_html')
 
     %fieldset
       %legend
@@ -17,7 +17,7 @@
 
       #stonith_sbd_container{ "data-nodes" => node_aliases.to_json }
         .alert.alert-info
-          = t(".stonith.sbd.info")
+          = t(".stonith.sbd.info_html")
         %table.table.table-middle
           %thead
             %tr

--- a/crowbar_framework/config/locales/pacemaker/en.yml
+++ b/crowbar_framework/config/locales/pacemaker/en.yml
@@ -67,7 +67,7 @@ en:
             "true" for two-nodes cluster, and to "false" otherwise.'
         crm:
           no_quorum_policy: 'Policy when cluster does not have quorum'
-          no_quorum_policy_hint: 'Refer to the <a href="http://clusterlabs.org/doc/en-US/Pacemaker/1.1-crmsh/html/Pacemaker_Explained/_available_cluster_options.html">pacemaker documentation</a> for a description of each value.'
+          no_quorum_policy_hint_html: 'Refer to the <a href="http://clusterlabs.org/doc/en-US/Pacemaker/1.1-crmsh/html/Pacemaker_Explained/_available_cluster_options.html">pacemaker documentation</a> for a description of each value.'
         stonith_header: 'STONITH'
         stonith_modes:
           manual: 'Configured manually'
@@ -80,7 +80,7 @@ en:
           mode: 'Configuration mode for STONITH'
           no_nodes: 'No nodes have been assigned a pacemaker role.'
           sbd:
-            info: 'Manual configuration is required for SBD: before applying the proposal, you will have to ensure that the devices are available and initialized for SBD; you will also need to setup a watchdog. Refer to the <a href="http://www.linux-ha.org/wiki/SBD_Fencing">Linux HA documentation</a> for details.'
+            info_html: 'Manual configuration is required for SBD: before applying the proposal, you will have to ensure that the devices are available and initialized for SBD; you will also need to setup a watchdog. Refer to the <a href="http://www.linux-ha.org/wiki/SBD_Fencing">Linux HA documentation</a> for details.'
             name: 'Node name'
             devices: 'Block devices for node'
             devices_hint: 'Multiple devices can be specified in the comma-separated list. It is advised to use a stable path for devices (with /dev/disk/by-id/, for instance).'


### PR DESCRIPTION
Otherwise, the whole `<a href=...>` is shown.