### PR TITLE
prevent internal server error in case dmi data is missing

### DIFF
--- a/crowbar_framework/app/models/pacemaker_service.rb
+++ b/crowbar_framework/app/models/pacemaker_service.rb
@@ -437,7 +437,8 @@ class PacemakerService < ServiceObject
       end
       members.each do |member|
         node = NodeObject.find_node_by_name(member)
-        unless %w(Bochs QEMU).include? node[:dmi][:system][:manufacturer]
+        manufacturer = node[:dmi][:system][:manufacturer] rescue "unknown"
+        unless %w(Bochs QEMU).include? manufacturer
           validation_error "Node  #{member} does not seem to be running in libvirt."
         end
       end


### PR DESCRIPTION
In case dmi data is missing and the nested hash values do not exist, accessing it wil raise and exception.  Rather stick with nil then and let validation_error do the error handling.