### PR TITLE
haproxy: Add forwardfor option by default in http mode

### DIFF
--- a/chef/cookbooks/haproxy/providers/loadbalancer.rb
+++ b/chef/cookbooks/haproxy/providers/loadbalancer.rb
@@ -53,7 +53,7 @@ action :create do
     if section['use_ssl']
       section['options'] = [['ssl-hello-chk', 'tcpka', 'tcplog'], section['options']].flatten
     elsif section['mode'] == 'http'
-      section['options'] = [['tcpka', 'httplog'], section['options']].flatten
+      section['options'] = [['tcpka', 'httplog', 'forwardfor'], section['options']].flatten
     end
   end
   section['servers'] = new_resource.servers


### PR DESCRIPTION
Having the X-Forwarded-For header is very useful for logging.

It's possible to get rid of it by choosing non-defaults options.