### PR TITLE
fix text in transition graphs

### DIFF
--- a/chef/cookbooks/hawk/attributes/default.rb
+++ b/chef/cookbooks/hawk/attributes/default.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-default[:hawk][:platform][:packages] = %w(hawk hawk-templates)
+default[:hawk][:platform][:packages] = %w(hawk hawk-templates xorg-x11-fonts)
 
 # Currently hardcoded in /srv/www/hawk/config/lighttp.conf and
 # /srv/www/hawk/app/views/dashboard/index.html.erb but added


### PR DESCRIPTION
Without Xorg fonts, Hawk (dot?) can't render the transition graphs properly.