### PR TITLE
[stoney] use alternative Pacemaker service provider for haproxy service

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/haproxy.rb
@@ -41,6 +41,7 @@ if node[:pacemaker][:haproxy][:clusters].has_key?(cluster_name) && node[:pacemak
     supports :restart => true, :status => true, :reload => true
     action :nothing
     subscribes :reload, "template[#{node[:haproxy][:platform][:config_file]}]", :immediately
+    provider Chef::Provider::CrowbarPacemakerService
   end
 
   vip_primitives = []


### PR DESCRIPTION
(Backport of #174 to stoney)

haproxy is under the control of Pacemaker, so it should be controlled via
Chef::Provider::CrowbarPacemakerService.  This not only ensures that 
start/stop/restart are performed through Pacemaker, but also ensures that
reload is only done when haproxy is already running.  This is important
because the haproxy init script currently handles the reload action in an
arguably broken way: it will start haproxy if it's not already running.  This
meant that if the haproxy config file changed, the reload subscription was
causing haproxy to start on nodes other than the one with the VIPs, which is
not what we want, and caused failures due to services being unable to bind to
the public VIP.