### PR TITLE
Fix proxying reload actions in Chef::Provider::CrowbarPacemakerService

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/service.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/service.rb
@@ -205,6 +205,7 @@ def proxy_action(resource, service_action)
   # otherwise we get warnings about the resource attributes being
   # cloned from the prior resource (CHEF-3694).
   service "pacemaker-#{service_action}-of-#{resource.name}" do
+    supports :restart => true, :reload => true
     service_name resource.service_name
     action :nothing
   end.run_action(service_action)


### PR DESCRIPTION
We explicitly need to tell that the service we're proxying to supports
reload.