### PR TITLE
Only deal with pacemaker resources on the founder node (bnc#918104)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/definitions/pacemaker_vip_primitive.rb
+++ b/chef/cookbooks/crowbar-pacemaker/definitions/pacemaker_vip_primitive.rb
@@ -10,8 +10,6 @@ define :pacemaker_vip_primitive, :cb_network => nil, :hostname => nil, :domain =
 
   primitive_name = "vip-#{params[:cb_network]}-#{params[:hostname]}"
 
-  # Allow one retry, to avoid races where two nodes create the primitive at the
-  # same time when it wasn't created yet (only one can obviously succeed)
   pacemaker_primitive primitive_name do
     agent "ocf:heartbeat:IPaddr2"
     params ({
@@ -19,8 +17,7 @@ define :pacemaker_vip_primitive, :cb_network => nil, :hostname => nil, :domain =
     })
     op params[:op]
     action :create
-    retries 1
-    retry_delay 5
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
   # we return the primitive name so that the caller can use it as part of a

--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -51,11 +51,13 @@ pacemaker_primitive service_name do
   params apache_params
   op    apache_op
   action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 pacemaker_clone "cl-#{service_name}" do
   rsc service_name
   action [ :create, :start ]
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # Override service provider for apache2 resource defined in apache2 cookbook


### PR DESCRIPTION
There's no real point in having all nodes try to update all pacemaker
resources all the time, and it actually can lead to issues due to races
when two non-founder nodes try to update the resource at the same time.

It's worth mentioning that for service LWRP, we actually want to do a
:start on each run to ensure that the service is restarted in case it
crashed. For pacemaker resources, the :start doesn't need to be done all
the time: as a crash of the service is caught by pacemaker already. So
if the founder goes missing, this won't hurt us.

http://bugzilla.suse.com/show_bug.cgi?id=918104