### PR TITLE
crowbar-pacemaker: Add crowbar_pacemaker_order_only_existing resource

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/order_only_existing.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/order_only_existing.rb
@@ -1,0 +1,46 @@
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See resource definition for how to use this LWRP.
+
+def delete_order(name)
+  pacemaker_order "#{name}-only-existing" do
+    name   name
+    action :nothing
+  end.run_action(:delete)
+end
+
+action :create do
+  # evil command line; there must be a better way to fetch the list of resources
+  # unfortunately, "crm_resource --list-raw" doesn't list groups/clones/etc.
+  all_resources = %x{crm configure show | awk '/^(primitive|group|clone|ms)/ {print $2}'}.split("\n")
+  ordering_for_existing_resources = new_resource.ordering.select { |r| all_resources.include?(r) }
+
+  if ordering_for_existing_resources.length <= 1
+    delete_order(new_resource.name)
+  else
+    pacemaker_order "#{new_resource.name}-only-existing" do
+      name     new_resource.name
+      score    new_resource.score
+      ordering ordering_for_existing_resources.join(" ")
+      action   :nothing
+    end.run_action(:create)
+  end
+end
+
+action :delete do
+  delete_order(new_resource.name)
+end

--- a/chef/cookbooks/crowbar-pacemaker/resources/order_only_existing.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/order_only_existing.rb
@@ -1,0 +1,50 @@
+#
+# Copyright 2015, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The goal of this resource is to make it possible to define ordering
+# constraints on a set of resources, while some of the resources exist in a
+# deployment, but not necessarily in this pacemaker cluster: we do not want to
+# include resources that do not exist in this cluster when creating the
+# ordering constraint.
+#
+# Example (using the default provider we ship):
+#
+# crowbar_pacemaker_order_only_existing "o-mywebapp" do
+#  score "Mandatory"
+#  ordering ["database", "apache", "mywebapp"]
+#  action :create
+# end
+#
+# If at least two resources among ["database", "apache", "mywebapp"] exist in
+# this HA cluster, then an ordering constraint will be created.  If there's one
+# resource that is not in this HA cluster, then it will be skipped. For
+# instance, if the database lives elsewhere, this resource will be equivalent
+# to:
+#
+# pacemaker_order "o-mywebapp" do
+#  score "Mandatory"
+#  ordering "apache mywebapp"
+#  action :create
+# end
+#
+
+actions :create, :delete
+
+default_action :create
+
+attribute :name,     :kind_of => String, :name_attribute => true
+attribute :score,    :kind_of => String
+attribute :ordering, :kind_of => Array


### PR DESCRIPTION
This is a hack that can be used to create order constraints easily when
some resources in the ordering might not exist in this cluster.