### PR TITLE
Switch corosync to use udpu by default for now (bsc#918409 and bsc#91517...

### DIFF
--- a/chef/data_bags/crowbar/bc-template-pacemaker.json
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.json
@@ -5,7 +5,7 @@
     "pacemaker": {
       "setup_hb_gui": false,
       "corosync": {
-        "transport": "udp",
+        "transport": "udpu",
         "mcast_addr": "239.255.0.1",
         "mcast_port": 5405,
         "password": "crowbar",


### PR DESCRIPTION
...6)

Workaround for:
https://bugzilla.suse.com/show_bug.cgi?id=918409 and
https://bugzilla.suse.com/show_bug.cgi?id=915176

Using multicast udp suddenly creates issues which cause fencing after deploying
the neutron-l3 role to a cluster. Switching to unicast udp helps us to
workaround those issues until we figured out the underlying root cause.
Also after some discussion with our Pacemaker experts the multicast variant
doesn't seem to offer too much of and advantage for the type of setup we
usually have.