### PR TITLE
Force output of "crm configure show" to not use colors

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/providers/order_only_existing.rb
+++ b/chef/cookbooks/crowbar-pacemaker/providers/order_only_existing.rb
@@ -26,7 +26,7 @@ end
 action :create do
   # evil command line; there must be a better way to fetch the list of resources
   # unfortunately, "crm_resource --list-raw" doesn't list groups/clones/etc.
-  all_resources = %x{crm configure show | awk '/^(primitive|group|clone|ms)/ {print $2}'}.split("\n")
+  all_resources = %x{crm --display=plain configure show | awk '/^(primitive|group|clone|ms)/ {print $2}'}.split("\n")
   ordering_for_existing_resources = new_resource.ordering.select { |r| all_resources.include?(r) }
 
   if ordering_for_existing_resources.length <= 1


### PR DESCRIPTION
We don't care about colors, we just want to parse plain text.

This allows us to avoid being hit by this crmsh bug:
https://bugzilla.novell.com/show_bug.cgi?id=893011

See also a3524fbc from #140