### PR TITLE
lvm: Compare real paths when checking for physical volumes (bsc#925476)

### DIFF
--- a/chef/cookbooks/lvm/libraries/provider_lvm_physical_volume.rb
+++ b/chef/cookbooks/lvm/libraries/provider_lvm_physical_volume.rb
@@ -19,6 +19,7 @@
 
 require 'chef/provider'
 require 'chef/mixin/shell_out'
+require 'pathname'
 
 class Chef
   class Provider
@@ -44,10 +45,10 @@ class Chef
         cmd.stdout.split("\n").each do |line|
           args = line.split()
           if args[0] == "PV" and args[1] == "Name"
-            physical_volumes << args[2]
+            physical_volumes << Pathname.new(args[2]).realpath.to_s
           end
         end
-        if physical_volumes.include?(new_resource.name)
+        if physical_volumes.include?(Pathname.new(new_resource.name).realpath.to_s)
           Chef::Log.info "Physical volume '#{new_resource.name}' found. Not creating..."
         else
           Chef::Log.info "Creating physical volume '#{new_resource.name}'"


### PR DESCRIPTION
Because what we might pass to pvcreate and what pvdisplay might show
could be different symlinks to the same device, we need to compare real
paths to the device instead of the input we get.

https://bugzilla.suse.com/show_bug.cgi?id=925476