### PR TITLE
change colocation resources from Array to String

### DIFF
--- a/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
+++ b/chef/cookbooks/pacemaker/libraries/pacemaker/constraint/colocation.rb
@@ -4,7 +4,20 @@ class Pacemaker::Constraint::Colocation < Pacemaker::Constraint
   TYPE = 'colocation'
   register_type TYPE
 
-  attr_accessor :score, :resources
+  attr_accessor :score
+  attr_reader :resources
+
+  def resources=(val)
+    case val
+    when Array
+      @resources = val.join ' '
+    when String
+      @resources = val
+    else
+      raise "Tried to set resources attribute for colocation '#{name}' " +
+        "to invalid type #{val.class} (#{val.inspect})"
+    end
+  end
 
   def self.attrs_to_copy_from_chef
     %w(score resources)
@@ -20,11 +33,11 @@ class Pacemaker::Constraint::Colocation < Pacemaker::Constraint
     end
     self.name  = $1
     self.score = $2
-    self.resources = $3.split
+    self.resources = $3
   end
 
   def definition_string
-    "#{self.class::TYPE} #{name} #{score}: " + resources.join(' ')
+    "#{self.class::TYPE} #{name} #{score}: #{resources}"
   end
 
 end

--- a/chef/cookbooks/pacemaker/resources/colocation.rb
+++ b/chef/cookbooks/pacemaker/resources/colocation.rb
@@ -24,6 +24,13 @@ default_action :create
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :score, :kind_of => String
 
-# If more than two resources are given, Pacemaker will treat this
-# as a resource set.
-attribute :resources, :kind_of => Array
+# If more than two resources are given, Pacemaker will treat this as a
+# resource set.  Originally this was an Array, but then we added
+# support for it alternatively being a String, in order to support
+# parentheses in the constraints passed to Pacemaker.  (Parentheses
+# allow sub-groups of resources which can be started in parallel.)  We
+# have kept Arrays for backwards compatibility, but they are
+# deprecated, because it's better if the responsibility of
+# understanding the structure of this part of the crm configure string
+# is delegated to Pacemaker.
+attribute :resources, :kind_of => [Array, String]

--- a/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
+++ b/chef/cookbooks/pacemaker/spec/fixtures/colocation_constraint.rb
@@ -7,8 +7,8 @@ module Chef::RSpec
       COLOCATION_CONSTRAINT = \
         ::Pacemaker::Constraint::Colocation.new('colocation1')
       COLOCATION_CONSTRAINT.score = 'inf'
-      COLOCATION_CONSTRAINT.resources = ['foo']
-      COLOCATION_CONSTRAINT_DEFINITION = 'colocation colocation1 inf: foo'
+      COLOCATION_CONSTRAINT.resources = 'rsc1 rsc2'
+      COLOCATION_CONSTRAINT_DEFINITION = 'colocation colocation1 inf: rsc1 rsc2'
     end
   end
 end

--- a/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/libraries/pacemaker/constraint/colocation_spec.rb
@@ -26,6 +26,30 @@ describe Pacemaker::Constraint::Colocation do
 
   it_should_behave_like "a CIB object"
 
+  describe "#new" do
+    before(:each) do
+      name = 'foo'
+      @resource_array = %w(rsc1 rsc2)
+      @resource_string = @resource_array.join ' '
+      @colocation = pacemaker_object_class.new(name)
+      @colocation.score = '-inf'
+      @definition_string = "colocation %s %s: %s" %
+        [ name, @colocation.score, @resource_string ]
+    end
+
+    it "should accept an String of resources" do
+      @colocation.resources = @resource_string
+      expect(@colocation.resources).to eq(@resource_string)
+      expect(@colocation.definition_string).to eq(@definition_string)
+    end
+
+    it "should accept an Array of resources" do
+      @colocation.resources = @resource_array
+      expect(@colocation.resources).to eq(@resource_string)
+      expect(@colocation.definition_string).to eq(@definition_string)
+    end
+  end
+
   describe "#definition_string" do
     it "should return the definition string" do
       expect(fixture.definition_string).to eq(fixture_definition)

--- a/chef/cookbooks/pacemaker/spec/providers/colocation_spec.rb
+++ b/chef/cookbooks/pacemaker/spec/providers/colocation_spec.rb
@@ -31,6 +31,15 @@ describe "Chef::Provider::PacemakerColocation" do
   describe ":create action" do
     include Chef::RSpec::Pacemaker::CIBObject
 
+    it "should accept resources provided in an Array" do
+      new_resources = %w(rsc1)
+      fixture.resources = new_resources
+      expected_configure_cmd_args = [fixture.reconfigure_command]
+      test_modify(expected_configure_cmd_args) do
+        @resource.resources new_resources
+      end
+    end
+
     it "should modify the constraint if it has a different score" do
       new_score = '100'
       fixture.score = new_score
@@ -43,7 +52,17 @@ describe "Chef::Provider::PacemakerColocation" do
     it "should modify the constraint if it has a resource added" do
       new_resource = 'bar:Stopped'
       expected = fixture.dup
-      expected.resources = expected.resources.dup + [new_resource]
+      expected.resources = expected.resources.dup + ' ' + new_resource
+      expected_configure_cmd_args = [expected.reconfigure_command]
+      test_modify(expected_configure_cmd_args) do
+        @resource.resources expected.resources
+      end
+    end
+
+    it "should modify the constraint if it has a resource added via an Array" do
+      new_resource = 'bar:Stopped'
+      expected = fixture.dup
+      expected.resources = expected.resources.dup.split + [new_resource]
       expected_configure_cmd_args = [expected.reconfigure_command]
       test_modify(expected_configure_cmd_args) do
         @resource.resources expected.resources
@@ -51,7 +70,7 @@ describe "Chef::Provider::PacemakerColocation" do
     end
 
     it "should modify the constraint if it has a different resource" do
-      new_resources = ['bar:Started']
+      new_resources = 'bar:Started'
       fixture.resources = new_resources
       expected_configure_cmd_args = [fixture.reconfigure_command]
       test_modify(expected_configure_cmd_args) do


### PR DESCRIPTION
**DO NOT MERGE YET** - untested.

This allows us to support more complex syntax involving parentheses etc. without having to implement a full parser.

Originally cherry picked from commit 7d1ea89 and then made backwards-compatible through Chef's polymorphic attributes.

Any future consumer of this LWRP which supplies the resources attribute
as a String instead of an Array will require this change.

Supercedes #92; 2nd commit of #92 was no longer necessary thanks to #186 taking a more robust approach to configuration.