### PR TITLE
[tex] Add attribute to set DNS name for haproxy admin IP address (bsc#927469)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/helpers.rb
@@ -66,6 +66,24 @@ module CrowbarPacemakerHelper
     end
   end
 
+  # The virtual admin name for the cluster is a name picked by the operator as
+  # an alias for the generated virtual FQDN. It might be wanted if the operator
+  # does not want to expose "cluster-foo.domain" to end users.
+  # This returns nil if there is no defined virtual admin name or if node is
+  # not member of a cluster.
+  def self.cluster_haproxy_vadmin_name(node)
+    if cluster_enabled?(node)
+      vadmin_name = node[:pacemaker][:haproxy][:admin_name]
+      if vadmin_name.nil? || vadmin_name.empty?
+        nil
+      else
+        vadmin_name
+      end
+    else
+      nil
+    end
+  end
+
   # The virtual public name for the cluster is a name picked by the operator as
   # an alias for the generated virtual FQDN. It might be wanted if the operator
   # does not want to expose "cluster-foo.domain" to end users.

--- a/chef/data_bags/crowbar/bc-template-pacemaker.json
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.json
@@ -44,6 +44,7 @@
         "enabled": false
       },
       "haproxy": {
+        "admin_name": "",
         "public_name": ""
       }
     }
@@ -52,7 +53,7 @@
     "pacemaker": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 10,
+      "schema-revision": 20,
       "element_states": {
         "pacemaker-cluster-member" : [ "readying", "ready", "applying" ],
         "hawk-server"              : [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-pacemaker.schema
+++ b/chef/data_bags/crowbar/bc-template-pacemaker.schema
@@ -124,6 +124,7 @@
               "type": "map",
               "required": true,
               "mapping": {
+                "admin_name": { "type": "str", "required": true },
                 "public_name": { "type": "str", "required": true }
               }
             }

--- a/chef/data_bags/crowbar/migrate/pacemaker/020_add_haproxy_admin_name.rb
+++ b/chef/data_bags/crowbar/migrate/pacemaker/020_add_haproxy_admin_name.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a['haproxy']['admin_name'] = ta['haproxy']['admin_name']
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['haproxy'].delete('admin_name')
+  return a, d
+end


### PR DESCRIPTION
**Backport of https://github.com/crowbar/barclamp-pacemaker/pull/190 to tex**

This is the exact same thing we're doing for the public IP address/DNS
name.

The reason it's needed is for keystone admin API which are being done
through the admin endpoint. As this is a rather minimal use case, we do
not expose the setting in the UI.

https://bugzilla.suse.com/show_bug.cgi?id=927469
(cherry picked from commit 04d82f3dd50e2ed629f1f646cca2d278878fe5cd)