### PR TITLE
Before claiming disk for DRBD, check if it is not mounted

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
@@ -26,7 +26,10 @@ claimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, claim_s
 
 if claimed_disks.empty? and not unclaimed_disks.empty?
   unclaimed_disks.each do |disk|
-    if disk.claim(claim_string)
+    %x{lsblk #{disk.name} --noheadings --output MOUNTPOINT | grep -q -v ^$}
+    if $?.exitstatus == 0
+      Chef::Log.info("#{claim_string}: Skipping #{disk.name}: disk already mounted")
+    elsif disk.claim(claim_string)
       Chef::Log.info("#{claim_string}: Claimed #{disk.name}")
       lvm_disk = disk
       break


### PR DESCRIPTION
Before claiming disk for DRBD, check if it is not
already mounted (it is possible such disk is not claimed by anyone)

This could help solve https://bugzilla.suse.com/show_bug.cgi?id=931048 where incorrect disk was selected for DRBD.

This solution alone could not help in all cases, e.g. when there are more disks available, even if not mounted in current system, it might not be correct to pick the first one available for DRBD.