### PR TITLE
For SBD and DRBD, use the disks that have relevant role assigned

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/drbd.rb
@@ -25,15 +25,34 @@ unclaimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node).sor
 claimed_disks = BarclampLibrary::Barclamp::Inventory::Disk.claimed(node, claim_string).sort
 
 if claimed_disks.empty? and not unclaimed_disks.empty?
+
+  disk_roles = node["crowbar_wall"].disk_roles
+  disk_for_drbd = disk_roles.find { |_, role| role == claim_string }[0] rescue ""
+
+  # if no disk has assigned DRBD role, take the first one without a role
   unclaimed_disks.each do |disk|
-    if disk.claim(claim_string)
-      Chef::Log.info("#{claim_string}: Claimed #{disk.unique_name}")
-      lvm_disk = disk
+    if disk_for_drbd == disk.unique_name
+      disk_to_claim = disk
       break
-    else
-      Chef::Log.info("#{claim_string}: Ignoring #{disk.unique_name}")
+    elsif (disk_roles[disk.unique_name] || "") == ""
+      disk_to_claim = disk
     end
   end
+
+  if disk_to_claim.nil?
+    message = "No unclaimed disk has DRBD role!"
+    Chef::Log.fatal(message)
+    raise message
+  end
+
+  if disk_to_claim.claim(claim_string)
+    Chef::Log.info("#{claim_string}: Claimed #{disk_to_claim.unique_name}")
+    lvm_disk = disk_to_claim
+    break
+  else
+    Chef::Log.info("#{claim_string}: Ignoring #{disk_to_claim.unique_name}")
+  end
+
 else
   lvm_disk = claimed_disks.first
 end

--- a/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/pacemaker/application.js
@@ -18,11 +18,17 @@
 ;(function($, doc, win) {
   'use strict';
 
+  var disks;
+
   function StonithNodeAgents(el, options) {
     this.root = $(el);
     this.html = {
       table_row: '<tr data-id="{0}" data-alias="{1}"><td>{1}</td><td><input type="text" class="form-control" value="{2}"/></td></tr>'
     };
+
+    if (disks == undefined) {
+      disks = this.root.data('disks');
+    }
 
     this.options = $.extend(
       {
@@ -141,7 +147,15 @@
 
     var rows = [];
     $.each(this.root.find('tbody tr'), function(index, tr) {
-      rows.push([$(tr).data('id'), $(tr).data('alias'), $(tr).find('input').val()]);
+      if (disks != undefined && disks[$(tr).data('id')] != undefined &&
+          $('#stonith_sbd_container').is(':visible'))
+      {
+        // if there's prepared value with sbd disk, fill it to the table
+        rows.push([$(tr).data('id'), $(tr).data('alias'), disks[$(tr).data('id')]]);
+      }
+      else {
+        rows.push([$(tr).data('id'), $(tr).data('alias'), $(tr).find('input').val()]);
+      }
     });
 
     // Sort by node alias

--- a/crowbar_framework/app/helpers/barclamp/pacemaker_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/pacemaker_helper.rb
@@ -21,6 +21,18 @@ module Barclamp
       Hash[nodes_hash.map { |n| [n.first, { :alias => n.last[:alias] }] }]
     end
 
+    def sbd_disks
+      ret = {}
+      nodes_hash.each do |n|
+        if n.last[:disk_roles]
+          ret[n.first] = n.last[:disk_roles].select { |_,role|
+            role == "sbd"
+          }.keys.join(",")
+        end
+      end
+      ret
+    end
+
     def transport_for_pacemaker(selected)
       options_for_select(
         [

--- a/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/pacemaker/_edit_attributes.html.haml
@@ -15,7 +15,7 @@
 
       = select_field %w(stonith mode), :collection => :stonith_mode_for_pacemaker, "data-showit" => ["sbd", "shared", "per_node", "libvirt"].join(";"), "data-showit-target" => "#stonith_sbd_container;#stonith_shared_container;#stonith_per_node_container;#stonith_libvirt_container", "data-showit-direct" => "true"
 
-      #stonith_sbd_container{ "data-nodes" => node_aliases.to_json }
+      #stonith_sbd_container{ "data-nodes" => node_aliases.to_json, "data-disks" => sbd_disks.to_json }
         .alert.alert-info
           = t(".stonith.sbd.info_html")
         %table.table.table-middle


### PR DESCRIPTION
For DRBD, claim the disk previously marked with DRBD role

This is the application of https://github.com/crowbar/barclamp-crowbar/pull/1306

For SBD, prefill the disk with SBD role into the pacemaker UI