### PR TITLE
Set cookbook names in metadata

### DIFF
--- a/chef/cookbooks/corosync/metadata.rb
+++ b/chef/cookbooks/corosync/metadata.rb
@@ -1,3 +1,4 @@
+name             "corosync"
 maintainer       "SUSE, GmbH"
 license          "Apache 2.0"
 description      "Installs and configures a base corosync installation"

--- a/chef/cookbooks/crowbar-pacemaker/metadata.rb
+++ b/chef/cookbooks/crowbar-pacemaker/metadata.rb
@@ -1,3 +1,4 @@
+name             "crowbar-pacemaker"
 maintainer       "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license          "Apache 2.0"

--- a/chef/cookbooks/drbd/metadata.rb
+++ b/chef/cookbooks/drbd/metadata.rb
@@ -1,3 +1,4 @@
+name              "drbd"
 maintainer        "Opscode, Inc."
 maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"

--- a/chef/cookbooks/haproxy/metadata.rb
+++ b/chef/cookbooks/haproxy/metadata.rb
@@ -1,3 +1,4 @@
+name             "haproxy"
 maintainer       "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Needed if the cookbook is used without the crowbar framework. I.e. using
the cookbook as berkshelf dependency.