### PR TITLE
fix cluster maintenance mode check for SLE12

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
+++ b/chef/cookbooks/crowbar-pacemaker/libraries/maintenance_mode_helpers.rb
@@ -19,7 +19,8 @@ module CrowbarPacemaker
   # Chef::Provider::PacemakerService LWRP.
   module MaintenanceModeHelpers
     def maintenance_mode?
-      !! (%x(crm node show #{node.hostname}) =~ /maintenance:\s*on/)
+      # See https://bugzilla.suse.com/show_bug.cgi?id=870696
+      !! (%x(crm_attribute -G -N #{node.hostname} -n maintenance -q) =~ /^on$/)
     end
 
     def record_maintenance_mode_before_this_chef_run


### PR DESCRIPTION
The output format of `crm node show` changed in SLE12 HAE, breaking this check.  Change it to use `crm_attribute` which produces more machine-readable output.  This was my original idea all along, except that at that time back in the SLE11 days, `crm_attribute` was too broken
to be usable:

  https://bugzilla.suse.com/show_bug.cgi?id=870696

However it's fine now in SLE12 (and this should even work in SLE11+updates, albeit with a spurious error, but that's not relevant in this Cloud 6 branch).