### PR TITLE
use systemd:apache2 RA on SLES12

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
+++ b/chef/cookbooks/crowbar-pacemaker/attributes/default.rb
@@ -22,8 +22,10 @@
 default[:pacemaker][:platform][:resource_packages][:openstack] = %w(openstack-resource-agents)
 
 if node.platform == 'suse' && node.platform_version.to_f >= 12.0
+  default[:pacemaker][:apache2][:agent] = "systemd:apache2"
   default[:pacemaker][:haproxy][:agent] = "systemd:haproxy"
 else
+  default[:pacemaker][:apache2][:agent] = "ocf:heartbeat:apache"
   default[:pacemaker][:haproxy][:agent] = "lsb:haproxy"
 end
 default[:pacemaker][:haproxy][:op][:monitor][:interval] = "10s"

--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -23,7 +23,6 @@
 # This is required for the OCF resource agent
 include_recipe "apache2::mod_status"
 
-agent_name = "ocf:heartbeat:apache"
 apache_op = {}
 apache_op["monitor"] = {}
 apache_op["monitor"]["interval"] = "10s"
@@ -39,9 +38,12 @@ unless crowbar_defined_ports.empty?
 end
 
 service_name = "apache2"
+agent_name = node[:pacemaker][service_name][:agent]
 
 apache_params = {}
-apache_params["statusurl"] = "http://127.0.0.1:#{listening_port}/server-status"
+unless agent_name == 'systemd:apache2'
+  apache_params["statusurl"] = "http://127.0.0.1:#{listening_port}/server-status"
+end
 unless crowbar_defined_ports.values.select{|service| service.has_key? :ssl}.empty?
   apache_params["options"] = "-DSSL"
 end

--- a/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
+++ b/chef/cookbooks/crowbar-pacemaker/recipes/apache.rb
@@ -38,7 +38,7 @@ unless crowbar_defined_ports.empty?
   listening_port = plain_ports.first unless (plain_ports.nil? || plain_ports.empty?)
 end
 
-service_name            = "apache"
+service_name = "apache2"
 
 apache_params = {}
 apache_params["statusurl"] = "http://127.0.0.1:#{listening_port}/server-status"


### PR DESCRIPTION
Unfortunately this missed Milestone 2 and appears to break Horizon when HA is used.  Tested this on c19 and it works.