### PR TITLE
fix bug preventing VIPs from being monitored

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/definitions/pacemaker_vip_primitive.rb
+++ b/chef/cookbooks/crowbar-pacemaker/definitions/pacemaker_vip_primitive.rb
@@ -1,6 +1,7 @@
 define :pacemaker_vip_primitive, :cb_network => nil, :hostname => nil, :domain => nil, :op => nil do
   network = params[:cb_network]
-  net_db = data_bag_item('crowbar', "#{network}_network")
+  op_params = params[:op]
+  net_db = data_bag_item("crowbar", "#{network}_network")
   raise "#{network}_network data bag missing?!" unless net_db
   fqdn = "#{params[:hostname]}.#{params[:domain]}"
   unless net_db["allocated_by_name"][fqdn]
@@ -15,7 +16,7 @@ define :pacemaker_vip_primitive, :cb_network => nil, :hostname => nil, :domain =
     params ({
       "ip" => ip_addr,
     })
-    op params[:op]
+    op op_params
     action :create
     only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end


### PR DESCRIPTION
(tex backport)

This was a very subtle and nasty bug which had gone unnoticed for a long time!  I was lucky to stumble across it whilst debugging the fallout from https://github.com/crowbar/crowbar-openstack/pull/3 - the restart of wicked dropped the admin and public VIPs for haproxy from the respective interfaces, which led me to wonder why Pacemaker didn't automatically resurrect them.

It turns out that the `vip-{admin,public}-cluster-services` primitives configured in Pacemaker were missing `op monitor interval="10s"`, but even though the `op` value was being passed to and correctly received by the `pacemaker_vip_primitive` definition, the LWRP was receiving an empty Hash even though it received all the other values correctly.

After much debugging deep in the internals of Chef, I finally realised that this was due to the `params` variable outside the definition block being overridden by the Chef resource's `params` method inside the block. So the fix is to use a temporary variable which doesn't clash with any other method in either context.

(cherry picked from commit 693dd78c9df16e14109245e135133677988f9f65)