### PR TITLE
haproxy: Decrease tune.maxrewrite from 8192 to 4096

### DIFF
--- a/chef/cookbooks/haproxy/attributes/default.rb
+++ b/chef/cookbooks/haproxy/attributes/default.rb
@@ -24,7 +24,7 @@ default[:haproxy][:platform][:config_file] = "/etc/haproxy/haproxy.cfg"
 
 default[:haproxy][:global][:maxconn] = 4096
 default[:haproxy][:global][:bufsize] = 16384
-default[:haproxy][:global][:maxrewrite] = 8192
+default[:haproxy][:global][:maxrewrite] = 4096
 default[:haproxy][:global][:chksize] = 16384
 
 default[:haproxy][:defaults][:balance] = "roundrobin"


### PR DESCRIPTION
(backport of https://github.com/crowbar/crowbar-ha/pull/19)

We reached a case again where the headers were too long and haproxy
errored out with 400 without passing the request to the backends.

Instead of increasing tune.bufsize (which is already quite high), we can
decrease tune.maxrewrite to fix it. Upstream says that 1024 is generally
enough, and that big values do create issues with long requests (like
the issue that was hit here). So decrease it a bit to avoid the current
problem.
