### PR TITLE
drbd: Use variable sync rate configuration (bsc#918621)

### DIFF
--- a/chef/cookbooks/drbd/attributes/default.rb
+++ b/chef/cookbooks/drbd/attributes/default.rb
@@ -1,3 +1,7 @@
+default["drbd"]["common"]["disk"]["c_plan_ahead"] = 20
+default["drbd"]["common"]["disk"]["c_max_rate"] = "100M"
+default["drbd"]["common"]["disk"]["c_fill_target"] = "15M"
+
 default["drbd"]["rsc"] = {}
 
 default[:drbd][:pacemaker][:agent] = "ocf:linbit:drbd"

--- a/chef/cookbooks/drbd/attributes/default.rb
+++ b/chef/cookbooks/drbd/attributes/default.rb
@@ -1,6 +1,18 @@
+# Comments for the c-* settings come from
+#   https://drbd.linbit.com/users-guide/s-configure-sync-rate.html
+#   https://blogs.linbit.com/p/128/drbd-sync-rate-controller/
+#   https://blogs.linbit.com/p/443/drbd-sync-rate-controller-2
+
+# Set c-plan-ahead to approximately 10 times the RTT; so if ping from one node
+# to the other says 200msec, configure 2 seconds (ie. a value of 20, as the
+# unit is tenths of a second).
 default["drbd"]["common"]["disk"]["c_plan_ahead"] = 20
-default["drbd"]["common"]["disk"]["c_max_rate"] = "100M"
-default["drbd"]["common"]["disk"]["c_fill_target"] = "15M"
+# The resync controller tries to use up as much network and disk bandwidth as
+# it can get, but no more than c-max-rate.
+default["drbd"]["common"]["disk"]["c_max_rate"] = "15M"
+# A good starting value for c-fill-target is BDPx3, where BDP is your bandwidth
+# delay product on the replication link.
+default["drbd"]["common"]["disk"]["c_fill_target"] = "5M"
 
 default["drbd"]["rsc"] = {}
 

--- a/chef/cookbooks/drbd/recipes/config.rb
+++ b/chef/cookbooks/drbd/recipes/config.rb
@@ -27,5 +27,10 @@ template "/etc/drbd.d/global_common.conf" do
   source "global_conf.erb"
   owner "root"
   group "root"
+  variables(
+    c_plan_ahead: node["drbd"]["common"]["disk"]["c_plan_ahead"],
+    c_max_rate: node["drbd"]["common"]["disk"]["c_max_rate"],
+    c_fill_target: node["drbd"]["common"]["disk"]["c_fill_target"]
+  )
   action :create
 end

--- a/chef/cookbooks/drbd/templates/default/global_conf.erb
+++ b/chef/cookbooks/drbd/templates/default/global_conf.erb
@@ -9,4 +9,9 @@ common {
     outdated-wfc-timeout 1;
     degr-wfc-timeout 1;
   }
+  disk {
+    c-plan-ahead <%= @c_plan_ahead %>;
+    c-max-rate <%= @c_max_rate %>;
+    c-fill-target <%= @c_fill_target %>;
+  }
 }


### PR DESCRIPTION
Backport of part of https://github.com/crowbar/crowbar-ha/pull/22 to tex.

This doesn't include the authentication change as I'm unsure how it'd behave for an existing drbd setup.
