### PR TITLE
Increase default timeout for sync_mark resource

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/sync_mark.rb
@@ -59,4 +59,4 @@ attribute :mark,      :kind_of => String,  :default => nil
 attribute :revision,  :kind_of => Integer, :default => nil
 
 attribute :fatal,     :kind_of => [TrueClass, FalseClass], :default => true
-attribute :timeout,   :kind_of => Integer, :default => 60
+attribute :timeout,   :kind_of => Integer, :default => 120


### PR DESCRIPTION
When deploying some of the later barclamps (e.g. heat) the chef-client run on
the founder can be significantly slower than on the non-founder nodes. The
default timeout of 60 seconds for the sync_mark resource can be easily reached
in that case, especially on slower machines.
