### PR TITLE
crowbar-pacemaker: Make / mount shared on boot (bsc#928161)

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/files/default/crowbar-ha-shared-mounts.init
+++ b/chef/cookbooks/crowbar-pacemaker/files/default/crowbar-ha-shared-mounts.init
@@ -1,0 +1,46 @@
+#! /bin/sh
+#
+# Copyright (c) 2015 SUSE, Inc.
+#
+# /etc/init.d/crowbar-ha-shared-mounts
+#
+### BEGIN INIT INFO
+# Provides:          crowbar-ha-shared-mounts
+# Required-Start:
+# Should-Start:
+# Required-Stop:
+# Should-Stop:
+# X-Start-Before:    drbd
+# Default-Start:     3 5
+# Default-Stop:      0 1 2 6
+# Description:       Make / mount shared
+### END INIT INFO
+
+. /etc/rc.status
+
+rc_reset
+
+case "$1" in
+    start)
+        mount --make-shared /
+        rc_status -v
+        ;;
+    stop)
+        rc_failed 0
+        rc_status -v
+        ;;
+
+    status)
+        rc_failed 4
+        rc_status -v
+        ;;
+    reload)
+        $0 start
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|status|reload}"
+        exit 1
+        ;;
+esac
+
+rc_exit


### PR DESCRIPTION
This is required when network namespaces are used, to avoid pacemaker to
be blocked while trying to unmount a drbd device.

This should have no major effect on the system, although it is a
behavior change in how mounts are used.

https://bugzilla.suse.com/show_bug.cgi?id=928161
