### PR TITLE
crowbar-pacemaker: Support String for ordering of order_only_existing

### DIFF
--- a/chef/cookbooks/crowbar-pacemaker/resources/order_only_existing.rb
+++ b/chef/cookbooks/crowbar-pacemaker/resources/order_only_existing.rb
@@ -48,3 +48,4 @@ default_action :create
 attribute :name,     :kind_of => String, :name_attribute => true
 attribute :score,    :kind_of => String
 attribute :ordering, :kind_of => Array
+attribute :ordering, :kind_of => [Array, String]


### PR DESCRIPTION
It can be useful to have non-sequential sets of dependencies in
crowbar_pacemaker_order_only_existing, so on top of supporting
definition of ordering as Array, we also need support as String which
lets us use the full syntax of crm.

This requires some pseudo-parsing of the crm syntax to make sure we
don't drop bits that shouldn't be dropped, but also to drop empty sets
after non-existing resources have been removed.

Backport of https://github.com/crowbar/crowbar-ha/pull/29
