### PR TITLE
[tex] Make Pacemaker retry start actions if they fail (bsc#965886)

### DIFF
--- a/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
+++ b/chef/cookbooks/pacemaker/templates/default/crm-initial.conf.erb
@@ -1,6 +1,7 @@
 property $id="cib-bootstrap-options" \
         stonith-enabled="<%= @stonith_enabled %>" \
         no-quorum-policy="<%= @no_quorum_policy %>" \
+        start-failure-is-fatal=false \
         placement-strategy="balanced"
 op_defaults $id="op-options" \
         timeout="<%= @op_default_timeout %>" \


### PR DESCRIPTION
**Backport of https://github.com/crowbar/crowbar-ha/pull/102 to `tex` (see https://github.com/crowbar/crowbar-ha/pull/107 for the 3.0 backport)**

If neutron-ha-tool fails to start (e.g. because `neutron-server` is not yet listening on a socket due the daemon still being in the startup phase) then we should retry a few times on the same node, rather than immediately migrating to the other node. We already have migration-threshold defaulting to 3, which makes sense in this case:

  https://bugzilla.suse.com/show_bug.cgi?id=965886

However this is not a fully reliable fix, since it's conceivable that the daemon could stay in the startup phase for longer than (migration-threshold \* number-of-nodes) retries.  So we will also need to make start-up of `neutron-server` (and maybe other daemons) asynchronous, i.e. blocking until the API endpoint is actually usable.

OTOH, in general retrying startup of services seems like a good idea, in order to catch transient failures.  Retries happen immediately and are capped by the migration-threshold default of 3, so it should not significantly slow down fail-overs and increase service downtime.  If in the future we only want to allow retries for certain resources, we can change the cluster-wide default migration-threshold to 1 (or 0?) and then increase it for individual resources.

Unfortunately there doesn't seem to be any best practice recommendations or considerations documented online regarding this cluster option, so to some extent we're relying on common sense to validate this change. However in a discussion on #clusterlabs IRC channel, Ken Gaillot confirmed that combining start-failure-is-fatal=false with a low migration-threshold value is a common and sane approach.  He also gave a reason why start-failure-is-fatal defaults to true:

```
<kgaillot> the idea is that start failures are usually due to misconfigurations of the underlying service, so don't bother retrying
<kgaillot> the types of things that can go wrong with startup are rarely transient. but for some services they are, so it's configurable
```

I guess it's partly historical too.

FWIW, here are some related links:

  http://blog.kennyrasschaert.be/blog/2013/12/18/pacemaker-high-failability/
  http://serverfault.com/questions/387425/make-pacemaker-retry-failed-resources
  http://thread.gmane.org/gmane.linux.highavailability.pacemaker/13531/focus=14897

(cherry picked from commit de94e1e42ba52c2cdb496becbd73f07bc2501871)
